### PR TITLE
Potential fix for code scanning alert no. 12: Useless assignment to local variable

### DIFF
--- a/src/utils/imageOptimizer.js
+++ b/src/utils/imageOptimizer.js
@@ -92,16 +92,13 @@ export function calculateExportSize(boardSizeCm, showCoords, exportQuality) {
   const maxCanvasSize = getMaxCanvasSize();
   let actualResolutionPixels;
   let physicalSizeCm;
-  let scaleFactor;
   if (mode === 'print') {
     const baseBoardPixels = cmToPixels(boardSizeCm);
     actualResolutionPixels = baseBoardPixels * exportQuality;
     physicalSizeCm = boardSizeCm;
-    scaleFactor = 1;
   } else {
     const baseBoardPixels = 2400;
-    scaleFactor = exportQuality / 24;
-    actualResolutionPixels = baseBoardPixels * scaleFactor;
+    actualResolutionPixels = baseBoardPixels * (exportQuality / 24);
     physicalSizeCm = null;
   }
   const params = getCoordinateParams(actualResolutionPixels);


### PR DESCRIPTION
Potential fix for [https://github.com/BilgeGates/chess_viewer/security/code-scanning/12](https://github.com/BilgeGates/chess_viewer/security/code-scanning/12)

Remove the unused local variable `scaleFactor` and its assignments in `calculateExportSize` within `src/utils/imageOptimizer.js`.

Best minimal fix (no behavior change):
- Delete `let scaleFactor;` declaration.
- Delete `scaleFactor = 1;` in the `'print'` branch.
- Replace `actualResolutionPixels = baseBoardPixels * scaleFactor;` with `actualResolutionPixels = baseBoardPixels * (exportQuality / 24);` in the `else` branch, and remove the separate `scaleFactor = exportQuality / 24;` assignment.

This preserves all outputs and control flow while removing useless assignments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
