### PR TITLE
Potential fix for code scanning alert no. 13: Unused variable, import, function or class

### DIFF
--- a/src/pages/SupportPage.jsx
+++ b/src/pages/SupportPage.jsx
@@ -5,7 +5,6 @@ import {
   BookOpen,
   ChevronDown,
   ExternalLink,
-  Github as GithubIcon,
   HelpCircle,
   MessageSquare
 } from 'lucide-react';


### PR DESCRIPTION
Potential fix for [https://github.com/BilgeGates/chess_viewer/security/code-scanning/13](https://github.com/BilgeGates/chess_viewer/security/code-scanning/13)

Remove `Github as GithubIcon` from the `lucide-react` import list in `src/pages/SupportPage.jsx`.

Best fix without changing functionality:
- Edit only the icon import block at the top of `src/pages/SupportPage.jsx`.
- Delete the `Github as GithubIcon,` specifier and keep all other imports unchanged.
- No new methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
