### PR TITLE
fix: improve export sizing and drag preview

### DIFF
--- a/src/components/features/ColorPicker/ColorPicker.jsx
+++ b/src/components/features/ColorPicker/ColorPicker.jsx
@@ -4,7 +4,12 @@ import { Palette } from 'lucide-react';
 
 import { ColorInput } from '@/components/features/ColorPicker/parts';
 import { useColorState } from '@/hooks';
-import { hexToRgb, rgbToHex, rgbToHsv, hsvToRgb } from '@/utils/colorConversions';
+import {
+  hexToRgb,
+  rgbToHex,
+  rgbToHsv,
+  hsvToRgb
+} from '@/utils/colorConversions';
 
 import PickerModal from './PickerModal';
 
@@ -65,7 +70,7 @@ function ColorPicker({ label, value = '#3B82F6', onChange, className = '' }) {
       ctx.fillStyle = gradientV;
       ctx.fillRect(0, 0, width, height);
     }
-  }, [isOpen, tempColor, hexToRgb, rgbToHsv, hsvToRgb]);
+  }, [isOpen, tempColor]);
   const handleCanvasClick = (e) => {
     const canvas = canvasRef.current;
     const rect = canvas.getBoundingClientRect();

--- a/src/components/features/Export/ExportOptionsDialog/ExportOptionsDialog.jsx
+++ b/src/components/features/Export/ExportOptionsDialog/ExportOptionsDialog.jsx
@@ -97,7 +97,7 @@ function ExportOptionsDialog({
                     <strong className="text-accent font-semibold">
                       Social:
                     </strong>{' '}
-                    Fixed large output optimized for social media and zooming.
+                    Keeps board size and increases export detail.
                   </>
                 )}
               </p>

--- a/src/components/interactions/ChessEditor/ChessEditor.jsx
+++ b/src/components/interactions/ChessEditor/ChessEditor.jsx
@@ -26,7 +26,6 @@ const CELL_SIZE = FIXED_BOARD_SIZE / 8; // 50px per cell
  * @param {string} props.lightSquare - Hex color for light squares
  * @param {string} props.darkSquare - Hex color for dark squares
  * @param {boolean} [props.flipped] - Whether to render from Black's perspective
- * @param {number} [props.boardSize=400] - Board size in pixels
  * @param {string} [props.className=''] - Additional CSS classes
  * @returns {JSX.Element}
  */
@@ -38,7 +37,7 @@ const ChessEditor = memo(function ChessEditor({
   lightSquare,
   darkSquare,
   flipped,
-  boardSize = FIXED_BOARD_SIZE,
+  onPieceImagesChange,
   className = ''
 }) {
   const { pieceImages, isLoading, loadProgress } = usePieceImages(pieceStyle);
@@ -55,6 +54,10 @@ const ChessEditor = memo(function ChessEditor({
   useEffect(() => {
     syncFromFen(fen);
   }, [fen, syncFromFen]);
+
+  useEffect(() => {
+    onPieceImagesChange?.(pieceImages);
+  }, [pieceImages, onPieceImagesChange]);
 
   /**
    * Moves a piece from the trash drop to the board handler.
@@ -126,7 +129,10 @@ const ChessEditor = memo(function ChessEditor({
       <div
         className={`flex flex-col 2xl:flex-row gap-6 2xl:items-start w-full overflow-visible ${className}`}
       >
-        <div className="flex-shrink-0 flex justify-center 2xl:justify-start animate-revealUp stagger-1" style={{ flexShrink: 0 }}>
+        <div
+          className="flex-shrink-0 flex justify-center 2xl:justify-start animate-revealUp stagger-1"
+          style={{ flexShrink: 0 }}
+        >
           <div
             className="relative flex flex-col"
             style={{
@@ -193,7 +199,7 @@ const ChessEditor = memo(function ChessEditor({
           </div>
 
           <div className="flex items-center justify-between">
-            <div className='flex gap-4'>
+            <div className="flex gap-4">
               <button
                 type="button"
                 onClick={(e) => {

--- a/src/components/interactions/CustomDragLayer/CustomDragLayer.jsx
+++ b/src/components/interactions/CustomDragLayer/CustomDragLayer.jsx
@@ -1,4 +1,5 @@
-import { memo, useLayoutEffect, useRef } from 'react';
+import { memo } from 'react';
+import { createPortal } from 'react-dom';
 
 import { useDragLayer } from 'react-dnd';
 
@@ -12,34 +13,26 @@ const CustomDragLayer = memo(function CustomDragLayer({
   pieceImages,
   boardSize = 400
 }) {
-  const dragPreviewRef = useRef(null);
-  const { itemType, isDragging, item, currentOffset } = useDragLayer(
-    (monitor) => ({
+  const { itemType, isDragging, item, currentOffset, sourceOffset } =
+    useDragLayer((monitor) => ({
       item: monitor.getItem(),
       itemType: monitor.getItemType(),
       currentOffset: monitor.getClientOffset(),
-      initialOffset: monitor.getInitialClientOffset(),
+      sourceOffset: monitor.getSourceClientOffset(),
       isDragging: monitor.isDragging()
-    })
-  );
-  useLayoutEffect(() => {
-    if (dragPreviewRef.current) {
-      if (isDragging) {
-        dragPreviewRef.current.style.willChange = 'transform';
-      } else {
-        dragPreviewRef.current.style.willChange = 'auto';
-      }
-    }
-  }, [isDragging]);
-  if (!isDragging || itemType !== ItemTypes.PIECE) {
+    }));
+  if (
+    !isDragging ||
+    itemType !== ItemTypes.PIECE ||
+    typeof document === 'undefined'
+  ) {
     return null;
   }
   const pieceImage = pieceImages[item?.pieceKey];
   if (!pieceImage) {
     return null;
   }
-  const SQUARE_SIZE = boardSize / 8;
-  const PIECE_SIZE = Math.round(SQUARE_SIZE * 0.85);
+  const pieceSize = Math.round((boardSize / 8) * 0.85);
   const layerStyles = {
     position: 'fixed',
     pointerEvents: 'none',
@@ -47,35 +40,27 @@ const CustomDragLayer = memo(function CustomDragLayer({
     left: 0,
     top: 0,
     right: 0,
-    bottom: 0,
-    contain: 'strict'
+    bottom: 0
   };
-  const getItemStyles = () => {
-    if (!currentOffset) {
-      return {
-        display: 'none'
-      };
-    }
-    const { x, y } = currentOffset;
-    const halfSize = PIECE_SIZE / 2;
-    const translateX = Math.round(x - halfSize);
-    const translateY = Math.round(y - halfSize);
-    return {
-      position: 'fixed',
-      left: 0,
-      top: 0,
-      transform: `translate3d(${translateX}px, ${translateY}px, 0)`,
-      WebkitTransform: `translate3d(${translateX}px, ${translateY}px, 0)`,
-      width: `${PIECE_SIZE}px`,
-      height: `${PIECE_SIZE}px`,
-      pointerEvents: 'none',
-      backfaceVisibility: 'hidden',
-      WebkitBackfaceVisibility: 'hidden'
-    };
+  const offset = sourceOffset || currentOffset;
+  if (!offset) {
+    return null;
+  }
+  const shift = sourceOffset ? 0 : pieceSize / 2;
+  const x = Math.round(offset.x - shift);
+  const y = Math.round(offset.y - shift);
+  const itemStyles = {
+    position: 'fixed',
+    left: 0,
+    top: 0,
+    transform: `translate3d(${x}px, ${y}px, 0)`,
+    width: `${pieceSize}px`,
+    height: `${pieceSize}px`,
+    pointerEvents: 'none'
   };
-  return (
+  return createPortal(
     <div style={layerStyles} aria-hidden="true">
-      <div ref={dragPreviewRef} style={getItemStyles()}>
+      <div style={itemStyles}>
         <img
           src={pieceImage.src}
           alt=""
@@ -88,13 +73,13 @@ const CustomDragLayer = memo(function CustomDragLayer({
             filter: 'drop-shadow(0 4px 12px rgba(0, 0, 0, 0.5))',
             pointerEvents: 'none',
             userSelect: 'none',
-            WebkitUserSelect: 'none',
-            imageRendering: 'auto'
+            WebkitUserSelect: 'none'
           }}
           draggable={false}
         />
       </div>
-    </div>
+    </div>,
+    document.body
   );
 });
 CustomDragLayer.displayName = 'CustomDragLayer';

--- a/src/constants/chessConstants.js
+++ b/src/constants/chessConstants.js
@@ -230,7 +230,7 @@ export const QUALITY_PRESETS = [
   {
     value: 24,
     label: 'Social 24×',
-    description: 'Social media / maximum zoom',
+    description: 'Keeps board size, higher zoom quality',
     mode: 'social',
     forceCoordinateBorder: true,
     estimatedSize: '400-600 KB'
@@ -238,7 +238,7 @@ export const QUALITY_PRESETS = [
   {
     value: 32,
     label: 'Max 32×',
-    description: 'Ultra high resolution',
+    description: 'Keeps board size, maximum zoom quality',
     mode: 'social',
     forceCoordinateBorder: true,
     estimatedSize: '800KB-1.2MB'
@@ -254,9 +254,9 @@ export const EXPORT_MODE_CONFIG = {
   social: {
     fixedBoardPixels: 4800,
     maxPixels: 16384,
-    preservePhysicalSize: false,
+    preservePhysicalSize: true,
     forceCoordinateBorder: true,
-    description: 'Fixed large output for zoom/social media'
+    description: 'Keeps board size with higher zoom quality'
   }
 };
 export const ADVANCED_FEN_CONFIG = {

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,15 +1,7 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useReducer,
-  useRef,
-  useState
-} from 'react';
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 
 import { useLocation } from 'react-router-dom';
 
-import { ChessBoard } from '@/components/board';
 import {
   ActionButtons,
   ControlPanel,
@@ -174,8 +166,8 @@ function HomePage() {
     addCurrentToFavorites
   } = useFENHistory(fen, setIsFavorite);
 
-  const boardRef = useRef(null);
   const addToFavoritesRef = useRef(null);
+  const [pieceImages, setPieceImages] = useState({});
 
   const { notifications, success, error, info, removeNotification } =
     useNotifications();
@@ -196,7 +188,7 @@ function HomePage() {
       darkSquare,
       flipped,
       fen,
-      pieceImages: boardRef.current?.getPieceImages() || {},
+      pieceImages,
       exportQuality
     };
   }, [
@@ -208,6 +200,7 @@ function HomePage() {
     darkSquare,
     flipped,
     fen,
+    pieceImages,
     exportQuality
   ]);
 
@@ -350,19 +343,6 @@ function HomePage() {
     }
   }, []);
 
-  const boardProps = useMemo(
-    () => ({
-      fen,
-      pieceStyle,
-      showCoords,
-      boardSize: 400,
-      lightSquare,
-      darkSquare,
-      flipped
-    }),
-    [fen, pieceStyle, showCoords, lightSquare, darkSquare, flipped]
-  );
-
   /**
    * @param {string} newFen - Updated FEN from editor
    * @returns {void}
@@ -390,13 +370,10 @@ function HomePage() {
                   lightSquare={lightSquare}
                   darkSquare={darkSquare}
                   flipped={flipped}
+                  onPieceImagesChange={setPieceImages}
                   className="2xl:h-full"
                 />
               </div>
-            </div>
-
-            <div className="sr-only" aria-hidden="true">
-              <ChessBoard ref={boardRef} {...boardProps} />
             </div>
 
             <div className="glass-card rounded-xl p-3 sm:p-4 lg:p-5 animate-revealUp stagger-3">

--- a/src/pages/SupportPage.jsx
+++ b/src/pages/SupportPage.jsx
@@ -5,7 +5,6 @@ import {
   BookOpen,
   ChevronDown,
   ExternalLink,
-  Github as GithubIcon,
   HelpCircle,
   MessageSquare
 } from 'lucide-react';
@@ -35,7 +34,7 @@ function SupportPage() {
         {}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-10 animate-fadeIn">
           <SupportCard
-            icon={<Github className="w-6 h-6" />}
+            icon={<HelpCircle className="w-6 h-6" />}
             title="GitHub Issues"
             desc="Report bugs or features"
             link="https://github.com/BilgeGates/chess_viewer/issues"

--- a/src/pages/settings/ExportCustomization.jsx
+++ b/src/pages/settings/ExportCustomization.jsx
@@ -237,7 +237,7 @@ const ExportCustomization = memo(function ExportCustomization({
                     <strong className="text-accent font-semibold">
                       Social:
                     </strong>{' '}
-                    Fixed large output optimized for social media and zooming.
+                    Keeps board size and increases export detail.
                   </>
                 )}
               </p>

--- a/src/utils/canvasRenderer.js
+++ b/src/utils/canvasRenderer.js
@@ -1,10 +1,7 @@
-import { EXPORT_MODE_CONFIG } from '@/constants';
-
-import { drawCoordinates, getCoordinateParams } from './coordinateCalculations';
+import { drawCoordinates } from './coordinateCalculations';
 import { parseFEN } from './fenParser';
 import {
-  cmToPixels,
-  getExportMode,
+  calculateExportSize,
   shouldForceCoordinateBorder
 } from './imageOptimizer';
 import { logger } from './logger';
@@ -51,7 +48,6 @@ export async function createUltraQualityCanvas(config) {
   if (exportQuality === undefined || exportQuality === null) {
     exportQuality = 8;
   }
-  const mode = getExportMode(exportQuality);
   const forceCoordBorder = shouldForceCoordinateBorder(exportQuality);
   const effectiveCoordBorder =
     showCoords && (forceCoordBorder || showCoordinateBorder);
@@ -97,17 +93,17 @@ export async function createUltraQualityCanvas(config) {
   }
 
   const imageKeys = Object.keys(pieceImages);
-  const imagePromises = imageKeys.map((key) => waitForPieceImage(pieceImages[key]));
+  const imagePromises = imageKeys.map((key) =>
+    waitForPieceImage(pieceImages[key])
+  );
   await Promise.all(imagePromises);
-  let finalBoardPixels;
-  if (mode === 'print') {
-    finalBoardPixels = cmToPixels(boardSizeCm) * exportQuality;
-  } else {
-    finalBoardPixels =
-      EXPORT_MODE_CONFIG.social.fixedBoardPixels * (exportQuality / 24);
-  }
-  const params = getCoordinateParams(finalBoardPixels);
-  const borderSize = showCoords ? params.borderSize : 0;
+  const exportSize = calculateExportSize(
+    boardSizeCm,
+    showCoords,
+    exportQuality
+  );
+  const finalBoardPixels = exportSize.boardPixels;
+  const borderSize = showCoords ? exportSize.borderSize : 0;
   const showThinFrame = config.showThinFrame || false;
   const shouldShowFrame =
     showThinFrame && (exportQuality === 8 || exportQuality === 16);

--- a/src/utils/imageOptimizer.js
+++ b/src/utils/imageOptimizer.js
@@ -90,45 +90,36 @@ function formatFileSize(bytes) {
 export function calculateExportSize(boardSizeCm, showCoords, exportQuality) {
   const mode = getExportMode(exportQuality);
   const maxCanvasSize = getMaxCanvasSize();
-  let actualResolutionPixels;
-  let physicalSizeCm;
-  if (mode === 'print') {
-    const baseBoardPixels = cmToPixels(boardSizeCm);
-    actualResolutionPixels = baseBoardPixels * exportQuality;
-    physicalSizeCm = boardSizeCm;
-  } else {
-    const baseBoardPixels = 2400;
-    actualResolutionPixels = baseBoardPixels * (exportQuality / 24);
-    physicalSizeCm = null;
-  }
-  const params = getCoordinateParams(actualResolutionPixels);
-  const borderSize = showCoords ? params.borderSize : 0;
-  const finalWidth = Math.round(borderSize + actualResolutionPixels);
-  const finalHeight = Math.round(actualResolutionPixels + borderSize);
-  let reducedWidth = finalWidth;
-  let reducedHeight = finalHeight;
-  let actualScaleFactor = 1.0;
-  if (finalWidth > maxCanvasSize || finalHeight > maxCanvasSize) {
-    const maxDim = Math.max(finalWidth, finalHeight);
-    actualScaleFactor = maxCanvasSize / maxDim;
-    reducedWidth = Math.round(finalWidth * actualScaleFactor);
-    reducedHeight = Math.round(finalHeight * actualScaleFactor);
+  const rawBoardPixels = cmToPixels(boardSizeCm) * exportQuality;
+  const coordParams = getCoordinateParams(rawBoardPixels);
+  const rawBorder = showCoords ? coordParams.borderSize : 0;
+  const rawWidth = Math.round(rawBorder + rawBoardPixels);
+  const rawHeight = Math.round(rawBoardPixels + rawBorder);
+  let width = rawWidth;
+  let height = rawHeight;
+  let scaleFactor = 1.0;
+  if (rawWidth > maxCanvasSize || rawHeight > maxCanvasSize) {
+    const maxDim = Math.max(rawWidth, rawHeight);
+    scaleFactor = maxCanvasSize / maxDim;
+    width = Math.round(rawWidth * scaleFactor);
+    height = Math.round(rawHeight * scaleFactor);
     logger.warn(
       'Resolution reduced by ' +
-        (actualScaleFactor * 100).toFixed(1) +
+        (scaleFactor * 100).toFixed(1) +
         '% for browser compatibility'
     );
   }
   return {
-    width: reducedWidth,
-    height: reducedHeight,
-    scaleFactor: actualScaleFactor,
-    baseBoardPixels: actualResolutionPixels,
-    baseWidth: finalWidth,
-    baseHeight: finalHeight,
-    borderSize,
-    physicalSizeCm,
-    effectiveDPI: mode === 'print' ? PRINT_DPI * exportQuality : null,
+    width,
+    height,
+    scaleFactor,
+    boardPixels: Math.round(rawBoardPixels * scaleFactor),
+    baseBoardPixels: rawBoardPixels,
+    baseWidth: rawWidth,
+    baseHeight: rawHeight,
+    borderSize: Math.round(rawBorder * scaleFactor),
+    physicalSizeCm: boardSizeCm,
+    effectiveDPI: Math.round(PRINT_DPI * exportQuality * scaleFactor),
     mode,
     exportQuality
   };


### PR DESCRIPTION
﻿## Summary
- Removed the hidden board render used only to access piece images during export.
- Made export size calculation keep the selected board size for 24x and 32x quality.
- Fixed the drag preview so pieces stay aligned with the pointer while dragging.
- Kept the implementation simple and close to the existing code style.

## Validation
- `corepack pnpm lint`
- `corepack pnpm build`
