### PR TITLE
Polish export flow and settings

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -21,7 +21,7 @@ Performance considerations and implemented optimisations for FENForsty Pro.
 FENForsty Pro is a client-side only application that performs canvas-based rendering and exports high-resolution images. Performance concerns fall into two areas:
 
 1. **Render performance** — keeping the interactive board and UI responsive during editing
-2. **Export performance** — generating very large canvases (up to 24,192×24,192 px) without crashing
+2. **Export performance** — generating large canvases while keeping browser limits visible to the user
 
 ---
 
@@ -59,11 +59,11 @@ Used throughout the codebase:
 
 ### Piece Image Caching
 
-`pieceImageCache.js` caches loaded `HTMLImageElement` instances by piece-set key. Images are loaded once per piece-set and reused for both display rendering and export. This avoids repeated network requests and re-decoding.
+`pieceImageCache.js` caches loaded `HTMLImageElement` instances by piece-set key. `usePieceImages` uses the same cache, so the editor, preview, and export code do not reload the same piece set separately.
 
 ### Export Pause/Resume
 
-The export loop in `canvasExporter.js` supports pausing (`pauseExport()`) and cancellation (`cancelExport()`). Without this, a 32× export would block any interactivity for the full duration of rendering.
+The export loop in `canvasExporter.js` supports pausing (`pauseExport()`) and cancellation (`cancelExport()`). Progress now follows real export stages such as preparation, canvas rendering, encoding, and download.
 
 ### History Archiving
 
@@ -94,25 +94,25 @@ A single `<Suspense>` boundary in `Router.jsx` shows a chess-themed loading spin
 
 Export memory is dominated by the canvas pixel buffer (`width × height × 4 bytes RGBA`):
 
-| Quality | Approx. Resolution | Approx. Memory |
-|---|---|---|
-| 8× @ 4 cm | 3,776 × 3,776 px | ~54 MB |
-| 8× @ 8 cm | 7,552 × 7,552 px | ~216 MB |
-| 16× @ 6 cm | 11,328 × 11,328 px | ~487 MB |
-| 24× (Social) | 18,112 × 18,112 px | ~1.24 GB |
-| 32× (Social) | 24,192 × 24,192 px | ~2.22 GB |
+| Quality    | Approx. Resolution | Approx. Memory |
+| ---------- | ------------------ | -------------- |
+| 8× @ 4 cm  | 3,776 × 3,776 px   | ~54 MB         |
+| 8× @ 8 cm  | 7,552 × 7,552 px   | ~216 MB        |
+| 16× @ 6 cm | 11,328 × 11,328 px | ~487 MB        |
+| 24× @ 4 cm | 11,328 × 11,328 px | ~489 MB        |
+| 32× @ 4 cm | 15,104 × 15,104 px | ~870 MB        |
 
-**Note:** 24× and 32× Social exports may exhaust available memory on devices with less than 4 GB RAM and are very likely to fail on iOS/Safari due to the WebKit canvas area limit.
+**Note:** 24× and 32× exports keep the selected board size and increase pixel density. The progress dialog shows a memory estimate before and during large exports.
 
 ---
 
 ## Browser Canvas Limits
 
-| Browser | Max Dimension | Notes |
-|---|---|---|
-| Chrome / Edge | 32,767 px | Chromium limit |
-| Firefox | 32,767 px | |
-| Safari | 16,384 px | Also limited to 268 MP total area |
+| Browser       | Max Dimension | Notes                             |
+| ------------- | ------------- | --------------------------------- |
+| Chrome / Edge | 32,767 px     | Chromium limit                    |
+| Firefox       | 32,767 px     |                                   |
+| Safari        | 16,384 px     | Also limited to 268 MP total area |
 
 `getMaxCanvasSize()` in `utils/index.js` detects and returns the safe maximum for the current browser. The export system sets `willBeReduced: true` when the requested dimensions exceed this cap.
 
@@ -122,11 +122,11 @@ Export memory is dominated by the canvas pixel buffer (`width × height × 4 byt
 
 ### Large Exports on Safari
 
-Safari enforces a 16,384 px and 268 MP canvas limit. Exports at 24× or 32× Social mode will fail or produce a blank image. This is a browser limitation with no workaround other than using a Chromium-based browser.
+Safari enforces a 16,384 px and 268 MP canvas limit. Very large exports can fail or produce a blank image. The export size helper reduces dimensions when the browser limit is reached.
 
 ### Canvas Full Redraw
 
-The interactive chess board (`ChessBoard`) redraws the entire canvas on every prop change. There is no partial update or dirty-checking. For the display board this is acceptable (64 squares × one `fillRect` each is fast), but it means any prop change triggers the full draw cycle.
+The main editor uses DOM squares for interaction. Canvas rendering is kept for export and small preview areas. The hidden export-only board render was removed, so normal page navigation has less background work.
 
 ### No Web Worker for Export
 
@@ -134,7 +134,7 @@ All canvas rendering during export runs on the main thread. On slow devices, ver
 
 ### Sequential Batch Export
 
-Batch export processes positions one at a time in sequence. There is a small `setTimeout` delay between positions to yield to the browser event loop, but large batches will still occupy the tab for an extended period.
+Batch export processes valid positions one at a time and gives each exported file a numbered name. This keeps memory usage lower than rendering several large canvases at once.
 
 ---
 
@@ -142,16 +142,16 @@ Batch export processes positions one at a time in sequence. There is a small `se
 
 `src/utils/performance.js` exports:
 
-| Export | Signature | Description |
-|---|---|---|
-| `debounce` | `(fn, wait = 300) => fn` | Returns a debounced version of `fn` |
-| `throttle` | `(fn, limit = 300) => fn` | Returns a time-throttled version of `fn` |
-| `rafThrottle` | `(fn) => fn & { cancel() }` | Returns an rAF-throttled version with a cancel method |
+| Export           | Signature                        | Description                                           |
+| ---------------- | -------------------------------- | ----------------------------------------------------- |
+| `debounce`       | `(fn, wait = 300) => fn`         | Returns a debounced version of `fn`                   |
+| `throttle`       | `(fn, limit = 300) => fn`        | Returns a time-throttled version of `fn`              |
+| `rafThrottle`    | `(fn) => fn & { cancel() }`      | Returns an rAF-throttled version with a cancel method |
 | `lazyLoadImages` | `(selector, options) => cleanup` | Sets up `IntersectionObserver` for lazy image loading |
 
 `src/hooks/usePerformance.js` wraps `performance.mark` / `performance.measure` for timing individual operations during development.
 
 ---
 
-**Last Updated:** March 3, 2026  
+**Last Updated:** April 27, 2026
 **Version:** 5.0.0

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",
     "lint:ci": "eslint . --max-warnings=500",
+    "test": "node --test src/utils/fenParser.test.js",
     "format": "prettier --write \"src/**/*.{js,jsx,json,css,md}\"",
     "format:check": "prettier . --check",
     "format:ci": "prettier . --check || exit 0",

--- a/src/components/features/ControlPanel/ControlPanel.jsx
+++ b/src/components/features/ControlPanel/ControlPanel.jsx
@@ -13,6 +13,7 @@ import { useNavigate } from 'react-router-dom';
 import DisplayOptions from '@/components/features/DisplayOptions';
 import { FENInputField, PieceSelector } from '@/components/features/Fen';
 import { useFENHistory } from '@/hooks';
+import { getFENValidationError } from '@/utils';
 
 /**
  * @param {Object} props
@@ -40,7 +41,7 @@ const ControlPanel = memo(function ControlPanel(props) {
     addCurrentToFavorites: externalAddCurrentToFavorites
   } = props;
   const [copySuccess, setCopySuccess] = useState(false);
-  const fenError = '';
+  const fenError = fen && fen.trim() ? getFENValidationError(fen) : '';
   const copyTimeoutRef = useRef(null);
   useEffect(() => {
     const timeout = copyTimeoutRef.current;

--- a/src/components/features/Export/ExportProgress/ExportProgress.jsx
+++ b/src/components/features/Export/ExportProgress/ExportProgress.jsx
@@ -3,6 +3,7 @@ import { memo, useEffect, useState } from 'react';
 import { FileImage, Pause, Play, XCircle } from 'lucide-react';
 
 import { Modal } from '@/components/ui';
+import { getExportInfo } from '@/utils';
 
 /**
  * @param {Object} props
@@ -12,6 +13,8 @@ const ExportProgress = memo(function ExportProgress({
   isExporting,
   progress,
   currentFormat,
+  config,
+  statusText,
   onClose,
   onPause,
   onResume,
@@ -38,6 +41,12 @@ const ExportProgress = memo(function ExportProgress({
   }, [isExporting]);
   if (!isExporting) return null;
   const format = currentFormat || 'png';
+  let exportInfo = null;
+  try {
+    exportInfo = config ? getExportInfo(config) : null;
+  } catch {
+    exportInfo = null;
+  }
   return (
     <Modal
       isOpen={isExporting}
@@ -51,8 +60,20 @@ const ExportProgress = memo(function ExportProgress({
     >
       <div className="space-y-5">
         <p className="text-sm text-text-secondary">
-          {isPaused ? '⏸ Paused' : 'Creating high-quality image...'}
+          {isPaused ? 'Paused' : statusText || 'Creating image...'}
         </p>
+
+        {exportInfo && (
+          <div className="text-xs text-text-muted bg-surface-elevated border border-border rounded-lg px-3 py-2 space-y-1">
+            <div>Size: {exportInfo.displaySize}</div>
+            <div>Memory estimate: {exportInfo.memoryEstimateMB} MB</div>
+            {exportInfo.isLargeExport && (
+              <div className="text-warning">
+                Large export. It may take longer on low-memory devices.
+              </div>
+            )}
+          </div>
+        )}
 
         <div className="space-y-3">
           <div

--- a/src/hooks/usePieceImages.js
+++ b/src/hooks/usePieceImages.js
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { PIECE_MAP } from '@/constants';
 import { logger } from '@/utils/logger';
+import { preloadPieceStyle, setCachedPieces } from '@/utils/pieceImageCache';
 
 /**
  * Loads and caches piece image elements for the given `pieceStyle`.
@@ -14,115 +15,35 @@ export function usePieceImages(pieceStyle) {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
   const [loadProgress, setLoadProgress] = useState(0);
-  const loadingRef = useRef(false);
-  const cacheRef = useRef({});
-  const abortControllerRef = useRef(null);
   const currentStyleRef = useRef(pieceStyle);
   useEffect(() => {
     currentStyleRef.current = pieceStyle;
-    if (loadingRef.current && abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
+    let cancelled = false;
     const loadPieces = async () => {
       const styleToLoad = pieceStyle;
-      loadingRef.current = true;
       setIsLoading(true);
       setError(null);
       setLoadProgress(0);
-      const cacheKey = styleToLoad;
-      if (cacheRef.current[cacheKey]) {
-        if (currentStyleRef.current === styleToLoad) {
-          setPieceImages(cacheRef.current[cacheKey]);
-          setIsLoading(false);
-          setLoadProgress(100);
-        }
-        loadingRef.current = false;
-        return;
-      }
-      const abortController = new AbortController();
-      abortControllerRef.current = abortController;
-      const images = {};
-      const entries = Object.entries(PIECE_MAP);
-      let loaded = 0;
-      const total = entries.length;
-      let hasError = false;
-      const loadPromises = entries.map(([key, value]) => {
-        return new Promise((resolve) => {
-          if (abortController.signal.aborted) {
-            resolve();
-            return;
-          }
-          const img = new Image();
-          img.crossOrigin = 'anonymous';
-          let retryCount = 0;
-          const maxRetries = 3;
-          let loadTimeout;
-          const cleanup = () => {
-            if (loadTimeout) clearTimeout(loadTimeout);
-            img.onload = null;
-            img.onerror = null;
-          };
-          const attemptLoad = () => {
-            if (abortController.signal.aborted) {
-              cleanup();
-              resolve();
-              return;
-            }
-            const cacheBuster = retryCount > 0 ? `?v=${Date.now()}` : '';
-            const url = `https://lichess1.org/assets/piece/${styleToLoad}/${value}.svg${cacheBuster}`;
-            loadTimeout = setTimeout(() => {
-              if (!abortController.signal.aborted) {
-                img.onerror(new Error('Timeout'));
-              }
-            }, 5000);
-            img.src = url;
-          };
-          img.onload = () => {
-            cleanup();
-            if (!abortController.signal.aborted) {
-              images[key] = img;
-              loaded++;
-              if (currentStyleRef.current === styleToLoad) {
-                setLoadProgress(Math.round((loaded / total) * 100));
-              }
-            }
-            resolve();
-          };
-          img.onerror = (err) => {
-            cleanup();
-            if (abortController.signal.aborted) {
-              resolve();
-              return;
-            }
-            logger.error(`Failed to load piece ${key}:`, err);
-            if (retryCount < maxRetries) {
-              retryCount++;
-              const delay = 500 * retryCount;
-              setTimeout(attemptLoad, delay);
-            } else {
-              logger.error(`Failed to load ${key} after ${maxRetries} retries`);
-              hasError = true;
-              images[key] = createPlaceholderImage(key);
-              loaded++;
-              if (currentStyleRef.current === styleToLoad) {
-                setLoadProgress(Math.round((loaded / total) * 100));
-              }
-              resolve();
-            }
-          };
-          attemptLoad();
-        });
-      });
       try {
-        await Promise.all(loadPromises);
-        if (
-          !abortController.signal.aborted &&
-          currentStyleRef.current === styleToLoad
-        ) {
+        const loadedImages = await preloadPieceStyle(
+          styleToLoad,
+          PIECE_MAP,
+          (progress) => {
+            if (!cancelled && currentStyleRef.current === styleToLoad) {
+              setLoadProgress(progress);
+            }
+          }
+        );
+        if (!cancelled && currentStyleRef.current === styleToLoad) {
+          const images = {};
+          let hasError = false;
+          Object.keys(PIECE_MAP).forEach((key) => {
+            images[key] = loadedImages[key] || createPlaceholderImage(key);
+            if (!loadedImages[key]) hasError = true;
+          });
           if (hasError) {
-            setError('Some pieces failed to load (using placeholders)');
-          } else {
-            cacheRef.current[cacheKey] = images;
+            setError('Some pieces failed to load');
+            setCachedPieces(styleToLoad, images);
           }
           setPieceImages({
             ...images
@@ -131,27 +52,16 @@ export function usePieceImages(pieceStyle) {
           setLoadProgress(100);
         }
       } catch (err) {
-        if (
-          !abortController.signal.aborted &&
-          currentStyleRef.current === styleToLoad
-        ) {
+        if (!cancelled && currentStyleRef.current === styleToLoad) {
           logger.error('Critical piece loading error:', err);
           setError('Failed to load pieces');
           setIsLoading(false);
-        }
-      } finally {
-        loadingRef.current = false;
-        if (abortControllerRef.current === abortController) {
-          abortControllerRef.current = null;
         }
       }
     };
     loadPieces();
     return () => {
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
-      loadingRef.current = false;
+      cancelled = true;
     };
   }, [pieceStyle]);
   return {

--- a/src/pages/AdvancedFENInputPage/AdvancedFENInputPage.jsx
+++ b/src/pages/AdvancedFENInputPage/AdvancedFENInputPage.jsx
@@ -12,7 +12,14 @@ import {
 import { ADVANCED_FEN_CONFIG } from '@/constants';
 import { useFENBatch } from '@/contexts';
 import { useChessBoard, usePieceImages, useTheme } from '@/hooks';
-import { logger, validateFEN } from '@/utils';
+import {
+  cancelExport,
+  getFENValidationError,
+  logger,
+  pauseExport,
+  resumeExport,
+  validateFEN
+} from '@/utils';
 import { safeJSONParse } from '@/utils/validation';
 
 import BoardDisplay from './BoardDisplay';
@@ -101,10 +108,13 @@ const AdvancedFENInputPage = memo(function AdvancedFENInputPage({
   );
   const [showThinFrame, setShowThinFrame] = useState(initialShowThinFrame);
   const [isExportModalOpen, setIsExportModalOpen] = useState(false);
-  const exportProgress = 0;
-  const currentFormat = '';
+  const [exportState, setExportState] = useState({
+    isExporting: false,
+    progress: 0,
+    currentFormat: '',
+    status: ''
+  });
   const [isPaused, setIsPaused] = useState(false);
-  const [showProgress, setShowProgress] = useState(false);
   const theme = useTheme({
     initialLight: initialLightSquare,
     initialDark: initialDarkSquare
@@ -154,13 +164,16 @@ const AdvancedFENInputPage = memo(function AdvancedFENInputPage({
         setPieceStyle(settings.pieceStyle ?? initialSettings.pieceStyle);
         setBoardSize(settings.boardSize ?? initialSettings.boardSize);
         setFileName(settings.fileName ?? initialSettings.fileName);
-        setExportQuality(settings.exportQuality ?? initialSettings.exportQuality);
+        setExportQuality(
+          settings.exportQuality ?? initialSettings.exportQuality
+        );
         setShowCoordsLocal(settings.showCoords ?? initialSettings.showCoords);
         setShowCoordinateBorder(
-          settings.showCoordinateBorder ??
-            initialSettings.showCoordinateBorder
+          settings.showCoordinateBorder ?? initialSettings.showCoordinateBorder
         );
-        setShowThinFrame(settings.showThinFrame ?? initialSettings.showThinFrame);
+        setShowThinFrame(
+          settings.showThinFrame ?? initialSettings.showThinFrame
+        );
         setIsFlipped(settings.isFlipped ?? false);
         setShowCoordinates(settings.showCoordinates ?? true);
         if (settings.lightSquare && settings.darkSquare) {
@@ -220,8 +233,10 @@ const AdvancedFENInputPage = memo(function AdvancedFENInputPage({
     const errors = {};
     fens.forEach((fen, index) => {
       const trimmed = fen.trim();
-      if (trimmed && !validateFEN(trimmed))
-        errors[index] = 'Invalid FEN notation';
+      if (trimmed) {
+        const error = getFENValidationError(trimmed);
+        if (error) errors[index] = error;
+      }
     });
     setFenErrors(errors);
     const validCount = fens.filter((f) => f.trim() && validateFEN(f)).length;
@@ -423,8 +438,36 @@ const AdvancedFENInputPage = memo(function AdvancedFENInputPage({
     lightSquare: theme.lightSquare,
     darkSquare: theme.darkSquare,
     flipped: isFlipped,
-    quality: exportQuality
+    pieceImages,
+    exportQuality
   };
+
+  function handleExportStart(format) {
+    setIsPaused(false);
+    setExportState({
+      isExporting: true,
+      progress: 0,
+      currentFormat: format,
+      status: 'Preparing'
+    });
+  }
+
+  function handleExportProgress(progress, format, status) {
+    setExportState({
+      isExporting: true,
+      progress,
+      currentFormat: format,
+      status: status || ''
+    });
+  }
+
+  function handleExportFinish() {
+    setExportState((prev) => ({
+      ...prev,
+      isExporting: false,
+      progress: 100
+    }));
+  }
 
   /**
    * Switches the editor back to the positions tab.
@@ -517,6 +560,7 @@ const AdvancedFENInputPage = memo(function AdvancedFENInputPage({
    * @returns {void}
    */
   function handlePauseExport() {
+    pauseExport();
     setIsPaused(true);
   }
 
@@ -526,6 +570,7 @@ const AdvancedFENInputPage = memo(function AdvancedFENInputPage({
    * @returns {void}
    */
   function handleResumeExport() {
+    resumeExport();
     setIsPaused(false);
   }
 
@@ -535,7 +580,11 @@ const AdvancedFENInputPage = memo(function AdvancedFENInputPage({
    * @returns {void}
    */
   function handleCancelExportProgress() {
-    setShowProgress(false);
+    cancelExport();
+    setExportState((prev) => ({
+      ...prev,
+      isExporting: false
+    }));
   }
 
   /**
@@ -640,7 +689,9 @@ const AdvancedFENInputPage = memo(function AdvancedFENInputPage({
                           fileName={fileName}
                           validFens={validFens}
                           onFlip={handleFlipBoard}
-                          onShowProgress={setShowProgress}
+                          onExportStart={handleExportStart}
+                          onExportProgress={handleExportProgress}
+                          onExportFinish={handleExportFinish}
                         />
                       </div>
                     </div>
@@ -672,11 +723,13 @@ const AdvancedFENInputPage = memo(function AdvancedFENInputPage({
         </div>
       </main>
 
-      {showProgress && (
+      {exportState.isExporting && (
         <ExportProgress
-          progress={exportProgress}
-          total={validFens.length}
-          currentFormat={currentFormat}
+          isExporting={exportState.isExporting}
+          progress={exportState.progress}
+          currentFormat={exportState.currentFormat}
+          statusText={exportState.status}
+          config={exportConfig}
           isPaused={isPaused}
           onPause={handlePauseExport}
           onResume={handleResumeExport}

--- a/src/pages/AdvancedFENInputPage/QuickActionsPanel.jsx
+++ b/src/pages/AdvancedFENInputPage/QuickActionsPanel.jsx
@@ -2,13 +2,7 @@ import { memo, useCallback } from 'react';
 
 import { Copy, FlipVertical2 } from 'lucide-react';
 
-import {
-  batchExport,
-  downloadJPEG,
-  downloadPNG,
-  downloadSVG,
-  logger
-} from '@/utils';
+import { downloadJPEG, downloadPNG, downloadSVG, logger } from '@/utils';
 
 /**
  * @typedef {Object} QuickActionsPanelProps
@@ -17,7 +11,9 @@ import {
  * @property {string} fileName - Base file name used for exported files.
  * @property {string[]} validFens - Array of valid FEN strings available for batch export.
  * @property {Function} onFlip - Callback invoked when the user clicks "Flip Board".
- * @property {Function} onShowProgress - Callback to show or hide the progress indicator.
+ * @property {Function} onExportStart - Called when an export starts.
+ * @property {Function} onExportProgress - Called with progress updates.
+ * @property {Function} onExportFinish - Called when export work ends.
  */
 
 /**
@@ -33,59 +29,88 @@ const QuickActionsPanel = memo(function QuickActionsPanel({
   fileName,
   validFens,
   onFlip,
-  onShowProgress
+  onExportStart,
+  onExportProgress,
+  onExportFinish
 }) {
   /**
    * Copies the current FEN string to the clipboard.
    *
    * @returns {Promise<void>}
    */
-  const handleCopyFen = useCallback(async function handleCopyFen() {
-    try {
-      await navigator.clipboard.writeText(currentFen);
-    } catch (err) {
-      logger.error('Copy failed:', err);
-    }
-  }, [currentFen]);
+  const handleCopyFen = useCallback(
+    async function handleCopyFen() {
+      try {
+        await navigator.clipboard.writeText(currentFen);
+      } catch (err) {
+        logger.error('Copy failed:', err);
+      }
+    },
+    [currentFen]
+  );
 
   /**
    * Exports the current position as a PNG.
    *
    * @returns {Promise<void>}
    */
-  const handleExportPng = useCallback(async function handleExportPng() {
-    try {
-      await downloadPNG(exportConfig, fileName);
-    } catch (err) {
-      logger.error('PNG export failed:', err);
-    }
-  }, [exportConfig, fileName]);
+  const handleExportPng = useCallback(
+    async function handleExportPng() {
+      try {
+        onExportStart?.('png');
+        await downloadPNG(exportConfig, fileName, (progress, label) => {
+          onExportProgress?.(progress, 'png', label);
+        });
+      } catch (err) {
+        logger.error('PNG export failed:', err);
+      } finally {
+        onExportFinish?.();
+      }
+    },
+    [exportConfig, fileName, onExportFinish, onExportProgress, onExportStart]
+  );
 
   /**
    * Exports the current position as a JPEG.
    *
    * @returns {Promise<void>}
    */
-  const handleExportJpeg = useCallback(async function handleExportJpeg() {
-    try {
-      await downloadJPEG(exportConfig, fileName);
-    } catch (err) {
-      logger.error('JPEG export failed:', err);
-    }
-  }, [exportConfig, fileName]);
+  const handleExportJpeg = useCallback(
+    async function handleExportJpeg() {
+      try {
+        onExportStart?.('jpeg');
+        await downloadJPEG(exportConfig, fileName, (progress, label) => {
+          onExportProgress?.(progress, 'jpeg', label);
+        });
+      } catch (err) {
+        logger.error('JPEG export failed:', err);
+      } finally {
+        onExportFinish?.();
+      }
+    },
+    [exportConfig, fileName, onExportFinish, onExportProgress, onExportStart]
+  );
 
   /**
    * Exports the current position as an SVG.
    *
    * @returns {Promise<void>}
    */
-  const handleExportSvg = useCallback(async function handleExportSvg() {
-    try {
-      await downloadSVG(exportConfig, fileName);
-    } catch (err) {
-      logger.error('SVG export failed:', err);
-    }
-  }, [exportConfig, fileName]);
+  const handleExportSvg = useCallback(
+    async function handleExportSvg() {
+      try {
+        onExportStart?.('svg');
+        await downloadSVG(exportConfig, fileName, (progress, label) => {
+          onExportProgress?.(progress, 'svg', label);
+        });
+      } catch (err) {
+        logger.error('SVG export failed:', err);
+      } finally {
+        onExportFinish?.();
+      }
+    },
+    [exportConfig, fileName, onExportFinish, onExportProgress, onExportStart]
+  );
 
   /**
    * Runs a batch export for all valid positions in a single format.
@@ -97,22 +122,46 @@ const QuickActionsPanel = memo(function QuickActionsPanel({
   const handleBatchExport = useCallback(
     async function handleBatchExport(format, label) {
       try {
-        onShowProgress(true);
-        await batchExport(
-          {
+        onExportStart?.(format);
+        for (let i = 0; i < validFens.length; i++) {
+          const fen = validFens[i];
+          const numberedName =
+            validFens.length > 1 ? `${fileName}-${i + 1}` : fileName;
+          const config = {
             ...exportConfig,
-            fens: validFens
-          },
-          [format],
-          fileName
-        );
-        onShowProgress(false);
+            fen
+          };
+          const reportProgress = (progress, _label) => {
+            const totalProgress =
+              ((i + progress / 100) / validFens.length) * 100;
+            onExportProgress?.(
+              totalProgress,
+              format,
+              `${i + 1}/${validFens.length}`
+            );
+          };
+          if (format === 'png') {
+            await downloadPNG(config, numberedName, reportProgress);
+          } else if (format === 'jpeg') {
+            await downloadJPEG(config, numberedName, reportProgress);
+          } else if (format === 'svg') {
+            await downloadSVG(config, numberedName, reportProgress);
+          }
+        }
       } catch (err) {
         logger.error(`${label} failed:`, err);
-        onShowProgress(false);
+      } finally {
+        onExportFinish?.();
       }
     },
-    [exportConfig, fileName, onShowProgress, validFens]
+    [
+      exportConfig,
+      fileName,
+      onExportFinish,
+      onExportProgress,
+      onExportStart,
+      validFens
+    ]
   );
 
   return (

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -1,11 +1,15 @@
 import { memo, useCallback, useEffect, useState } from 'react';
 
-import { Download, Palette } from 'lucide-react';
+import { Database, Download, Palette } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { ToolPageHeader } from '@/components/layout';
 import { useLocalStorage } from '@/hooks';
-import { ExportCustomization, ThemeCustomization } from '@/pages/settings';
+import {
+  DataManagement,
+  ExportCustomization,
+  ThemeCustomization
+} from '@/pages/settings';
 
 const pageTabs = [
   {
@@ -19,6 +23,12 @@ const pageTabs = [
     label: 'Export Customization',
     shortLabel: 'Export',
     icon: Download
+  },
+  {
+    id: 'data',
+    label: 'Data Management',
+    shortLabel: 'Data',
+    icon: Database
   }
 ];
 /**
@@ -58,7 +68,9 @@ const SettingsPage = memo(function SettingsPage() {
                 onClick={() => setActiveTab(id)}
                 className={`px-3 sm:px-5 py-2.5 sm:py-3 flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm font-semibold transition-all duration-300 border-b-2 whitespace-nowrap hover:scale-105 active:scale-95 ${activeTab === id ? 'text-accent border-accent bg-accent/5 scale-105' : 'text-text-secondary hover:text-text-primary border-transparent hover:bg-surface-hover'}`}
               >
-                <Icon className={`w-3.5 h-3.5 sm:w-4 sm:h-4 transition-transform duration-300 ${activeTab === id ? 'scale-110' : ''}`} />
+                <Icon
+                  className={`w-3.5 h-3.5 sm:w-4 sm:h-4 transition-transform duration-300 ${activeTab === id ? 'scale-110' : ''}`}
+                />
                 <span className="sm:hidden">{shortLabel}</span>
                 <span className="hidden sm:inline">{label}</span>
               </button>
@@ -84,6 +96,11 @@ const SettingsPage = memo(function SettingsPage() {
                 exportQuality={exportQuality}
                 setExportQuality={setExportQuality}
               />
+            </div>
+          )}
+          {activeTab === 'data' && (
+            <div className="h-full animate-pageEnter">
+              <DataManagement />
             </div>
           )}
         </div>

--- a/src/pages/settings/DataManagement.jsx
+++ b/src/pages/settings/DataManagement.jsx
@@ -1,0 +1,141 @@
+import { memo, useRef, useState } from 'react';
+
+import { Download, RotateCcw, Upload } from 'lucide-react';
+
+import { safeJSONParse } from '@/utils/validation';
+
+const STORAGE_KEYS = [
+  'chess-fen',
+  'chess-piece-style',
+  'chess-show-coords',
+  'chess-show-coordinate-border',
+  'chess-show-thin-frame',
+  'chess-light-square',
+  'chess-dark-square',
+  'chess-board-size',
+  'chess-flipped',
+  'chess-file-name',
+  'chess-export-quality',
+  'fen-history',
+  'fen-history-archive',
+  'favoriteFens',
+  'fenClipboardHistory',
+  'fenBatchList',
+  'advancedFENFavorites',
+  'advanced-fen-position-settings',
+  'themeSettings',
+  'recentColors',
+  'customThemePresets'
+];
+
+const DataManagement = memo(function DataManagement() {
+  const fileInputRef = useRef(null);
+  const [message, setMessage] = useState('');
+
+  function handleExportData() {
+    const data = {};
+    STORAGE_KEYS.forEach((key) => {
+      const value = localStorage.getItem(key);
+      if (value !== null) {
+        data[key] = value;
+      }
+    });
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json'
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'chess-viewer-data.json';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    setMessage('Data exported');
+  }
+
+  async function handleImportFile(event) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    const data = safeJSONParse(text, null);
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      setMessage('Invalid backup file');
+      return;
+    }
+    STORAGE_KEYS.forEach((key) => {
+      if (Object.prototype.hasOwnProperty.call(data, key)) {
+        const value = data[key];
+        localStorage.setItem(
+          key,
+          typeof value === 'string' ? value : JSON.stringify(value)
+        );
+      }
+    });
+    setMessage('Data imported. Refresh the page to see all changes.');
+    event.target.value = '';
+  }
+
+  function handleResetData() {
+    if (!window.confirm('Reset saved app data on this browser?')) return;
+    STORAGE_KEYS.forEach((key) => localStorage.removeItem(key));
+    setMessage('Data reset. Refresh the page to start clean.');
+  }
+
+  return (
+    <div className="h-full flex items-center justify-center p-4">
+      <div className="max-w-md w-full space-y-5">
+        <div>
+          <h3 className="text-lg font-semibold text-text-primary">
+            Data Management
+          </h3>
+          <p className="text-sm text-text-secondary mt-1">
+            Export, import, or reset local browser data.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <button
+            type="button"
+            onClick={handleExportData}
+            className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-accent hover:bg-accent-hover text-bg rounded-lg font-semibold transition-colors"
+          >
+            <Download className="w-4 h-4" />
+            Export Data
+          </button>
+
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-surface-elevated hover:bg-surface-hover border border-border text-text-primary rounded-lg font-semibold transition-colors"
+          >
+            <Upload className="w-4 h-4" />
+            Import Data
+          </button>
+
+          <button
+            type="button"
+            onClick={handleResetData}
+            className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-error/10 hover:bg-error/20 border border-error/30 text-error rounded-lg font-semibold transition-colors"
+          >
+            <RotateCcw className="w-4 h-4" />
+            Reset Local Data
+          </button>
+        </div>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/json,.json"
+          onChange={handleImportFile}
+          className="hidden"
+        />
+
+        {message && <p className="text-sm text-text-secondary">{message}</p>}
+      </div>
+    </div>
+  );
+});
+
+DataManagement.displayName = 'DataManagement';
+export default DataManagement;

--- a/src/pages/settings/index.js
+++ b/src/pages/settings/index.js
@@ -1,2 +1,3 @@
 export { default as ThemeCustomization } from './ThemeCustomization';
 export { default as ExportCustomization } from './ExportCustomization';
+export { default as DataManagement } from './DataManagement';

--- a/src/utils/canvasExporter.js
+++ b/src/utils/canvasExporter.js
@@ -45,22 +45,14 @@ function checkCancellation() {
     throw new Error('Export cancelled');
   }
 }
-async function simulateProgress(onProgress, start, end, duration) {
-  const steps = 20;
-  const stepSize = (end - start) / steps;
-  const stepDuration = duration / steps;
-  for (let i = 0; i < steps; i++) {
-    await waitWhilePaused();
-    checkCancellation();
-    const progress = start + stepSize * (i + 1);
-    const clampedProgress = Math.min(progress, end);
-    if (onProgress) {
-      onProgress(clampedProgress);
-    }
-    await new Promise(function (resolve) {
-      setTimeout(resolve, stepDuration);
-    });
+function setProgress(onProgress, value, label) {
+  if (onProgress) {
+    onProgress(value, label);
   }
+}
+
+function estimateMemoryMB(width, height) {
+  return Math.round((width * height * 4) / 1024 / 1024);
 }
 /**
  * Returns metadata about the planned export (dimensions, DPI, file size estimate).
@@ -90,7 +82,9 @@ export function getExportInfo(config) {
     requestedQuality: exportQuality,
     actualQuality: exportSize.scaleFactor,
     maxCanvasSize: maxSize,
-    willBeReduced: exportSize.width > maxSize || exportSize.height > maxSize,
+    willBeReduced: exportSize.scaleFactor < 1,
+    memoryEstimateMB: estimateMemoryMB(exportSize.width, exportSize.height),
+    isLargeExport: estimateMemoryMB(exportSize.width, exportSize.height) > 512,
     fileSizeEstimate: fileSizes,
     mode: mode,
     physicalSizeCm: exportSize.physicalSizeCm,
@@ -140,10 +134,7 @@ export async function downloadPNG(config, fileName, onProgress) {
   try {
     validateExportConfig(config);
     const safeFileName = sanitizeFileName(fileName);
-    if (onProgress) {
-      onProgress(5);
-    }
-    await simulateProgress(onProgress, 5, 15, 300);
+    setProgress(onProgress, 5, 'Preparing');
     await waitWhilePaused();
     checkCancellation();
     const pngConfig = Object.assign({}, config, {
@@ -153,10 +144,7 @@ export async function downloadPNG(config, fileName, onProgress) {
     if (!canvas) {
       throw new Error('Canvas creation returned null');
     }
-    if (onProgress) {
-      onProgress(30);
-    }
-    await simulateProgress(onProgress, 30, 50, 400);
+    setProgress(onProgress, 45, 'Canvas ready');
     await waitWhilePaused();
     checkCancellation();
     const blob = await new Promise(function (resolve, reject) {
@@ -184,7 +172,7 @@ export async function downloadPNG(config, fileName, onProgress) {
         reject(err);
       }
     });
-    await simulateProgress(onProgress, 50, 80, 300);
+    setProgress(onProgress, 85, 'Image encoded');
     await waitWhilePaused();
     checkCancellation();
     const url = URL.createObjectURL(blob);
@@ -193,9 +181,7 @@ export async function downloadPNG(config, fileName, onProgress) {
     link.download = safeFileName + '.png';
     document.body.appendChild(link);
     link.click();
-    if (onProgress) {
-      onProgress(100);
-    }
+    setProgress(onProgress, 100, 'Done');
     setTimeout(function () {
       if (document.body.contains(link)) {
         document.body.removeChild(link);
@@ -228,10 +214,7 @@ export async function downloadJPEG(config, fileName, onProgress) {
   try {
     validateExportConfig(config);
     const safeFileName = sanitizeFileName(fileName);
-    if (onProgress) {
-      onProgress(5);
-    }
-    await simulateProgress(onProgress, 5, 15, 300);
+    setProgress(onProgress, 5, 'Preparing');
     await waitWhilePaused();
     checkCancellation();
     const jpegConfig = Object.assign({}, config, {
@@ -241,10 +224,7 @@ export async function downloadJPEG(config, fileName, onProgress) {
     if (!canvas) {
       throw new Error('Canvas creation returned null');
     }
-    if (onProgress) {
-      onProgress(25);
-    }
-    await simulateProgress(onProgress, 25, 35, 300);
+    setProgress(onProgress, 35, 'Canvas ready');
     await waitWhilePaused();
     checkCancellation();
     const tempCanvas = document.createElement('canvas');
@@ -263,10 +243,7 @@ export async function downloadJPEG(config, fileName, onProgress) {
     ctx.imageSmoothingEnabled = true;
     ctx.imageSmoothingQuality = 'high';
     ctx.drawImage(canvas, 0, 0);
-    if (onProgress) {
-      onProgress(45);
-    }
-    await simulateProgress(onProgress, 45, 60, 400);
+    setProgress(onProgress, 60, 'JPEG background ready');
     await waitWhilePaused();
     checkCancellation();
     const jpegQuality = 0.92;
@@ -295,7 +272,7 @@ export async function downloadJPEG(config, fileName, onProgress) {
         reject(err);
       }
     });
-    await simulateProgress(onProgress, 60, 85, 300);
+    setProgress(onProgress, 85, 'Image encoded');
     await waitWhilePaused();
     checkCancellation();
     const url = URL.createObjectURL(blob);
@@ -304,9 +281,7 @@ export async function downloadJPEG(config, fileName, onProgress) {
     link.download = safeFileName + '.jpg';
     document.body.appendChild(link);
     link.click();
-    if (onProgress) {
-      onProgress(100);
-    }
+    setProgress(onProgress, 100, 'Done');
     setTimeout(function () {
       if (document.body.contains(link)) {
         document.body.removeChild(link);

--- a/src/utils/fenParser.js
+++ b/src/utils/fenParser.js
@@ -69,12 +69,23 @@ export function parseFEN(fenString) {
  * @returns {boolean} True if the FEN piece placement is valid
  */
 export function validateFEN(fen) {
+  return getFENValidationError(fen) === '';
+}
+
+/**
+ * Returns a short user-facing error for invalid piece placement.
+ *
+ * @param {string} fen - FEN notation string
+ * @returns {string} Empty string when valid
+ */
+export function getFENValidationError(fen) {
   try {
-    if (!fen || typeof fen !== 'string') return false;
+    if (!fen || typeof fen !== 'string') return 'FEN is empty';
     const position = fen.trim().split(/\s+/)[0];
     const rows = position.split('/');
-    if (rows.length !== 8) return false;
-    for (const row of rows) {
+    if (rows.length !== 8) return 'Board must have 8 ranks';
+    for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+      const row = rows[rowIndex];
       let count = 0;
       for (const char of row) {
         if (VALID_DIGITS.has(char)) {
@@ -82,14 +93,16 @@ export function validateFEN(fen) {
         } else if (VALID_PIECES.has(char)) {
           count++;
         } else {
-          return false;
+          return 'Invalid piece character: ' + char;
         }
       }
-      if (count !== 8) return false;
+      if (count !== 8) {
+        return 'Rank ' + (rowIndex + 1) + ' has ' + count + ' squares';
+      }
     }
-    return true;
+    return '';
   } catch {
-    return false;
+    return 'Invalid FEN';
   }
 }
 

--- a/src/utils/fenParser.test.js
+++ b/src/utils/fenParser.test.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getFENValidationError, validateFEN } from './fenParser.js';
+
+test('validates a normal starting position', () => {
+  const fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+  assert.equal(validateFEN(fen), true);
+  assert.equal(getFENValidationError(fen), '');
+});
+
+test('returns a readable error for a short rank', () => {
+  const fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPP/RNBQKBNR w KQkq - 0 1';
+  assert.equal(validateFEN(fen), false);
+  assert.match(getFENValidationError(fen), /Rank 7/);
+});
+
+test('returns a readable error for a wrong piece character', () => {
+  const fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPX/RNBQKBNR w KQkq - 0 1';
+  assert.equal(validateFEN(fen), false);
+  assert.equal(getFENValidationError(fen), 'Invalid piece character: X');
+});

--- a/src/utils/pieceImageCache.js
+++ b/src/utils/pieceImageCache.js
@@ -56,17 +56,22 @@ export function clearPieceCache() {
  * @param {Record<string, string>} PIECE_MAP - Map of piece keys to SVG filenames
  * @returns {Promise<Object>} Resolved piece image map
  */
-export async function preloadPieceStyle(pieceStyle, PIECE_MAP) {
+export async function preloadPieceStyle(pieceStyle, PIECE_MAP, onProgress) {
   const cached = getCachedPieces(pieceStyle);
   if (cached) {
+    onProgress?.(100);
     return cached;
   }
   if (loadingPromises.has(pieceStyle)) {
-    return loadingPromises.get(pieceStyle);
+    return loadingPromises.get(pieceStyle).then((images) => {
+      onProgress?.(100);
+      return images;
+    });
   }
   markStyleLoading(pieceStyle);
   const images = {};
   const keys = Object.keys(PIECE_MAP);
+  let loaded = 0;
   const promise = Promise.all(
     keys.map(
       (key) =>
@@ -81,10 +86,14 @@ export async function preloadPieceStyle(pieceStyle, PIECE_MAP) {
             '.svg';
           img.onload = function () {
             images[key] = img;
+            loaded++;
+            onProgress?.(Math.round((loaded / keys.length) * 100));
             resolve();
           };
           img.onerror = function () {
             images[key] = null;
+            loaded++;
+            onProgress?.(Math.round((loaded / keys.length) * 100));
             resolve();
           };
           img.src = url;

--- a/src/utils/svgExporter.js
+++ b/src/utils/svgExporter.js
@@ -1,4 +1,5 @@
 import { parseFEN } from './fenParser';
+import { shouldForceCoordinateBorder } from './imageOptimizer';
 import { logger } from './logger';
 import { sanitizeFileName } from './validation';
 
@@ -59,7 +60,8 @@ export async function generateBoardSVG(config) {
     pieceImages,
     showCoords,
     showCoordinateBorder,
-    showThinFrame
+    showThinFrame,
+    exportQuality
   } = config;
   const boardPx = SVG_BOARD_PX;
   const squarePx = boardPx / 8;
@@ -67,7 +69,11 @@ export async function generateBoardSVG(config) {
   const borderPx = withCoords
     ? Math.round(Math.max(18, Math.min(800, boardPx * SVG_COORD_BORDER_RATIO)))
     : 0;
-  const withFrame = !!showThinFrame;
+  const withBorder =
+    withCoords &&
+    (showCoordinateBorder || shouldForceCoordinateBorder(exportQuality));
+  const withFrame =
+    !!showThinFrame && (exportQuality === 8 || exportQuality === 16);
   const framePx = withFrame ? Math.max(2, Math.round(boardPx * 0.003)) * 2 : 0;
   const totalWidth = borderPx + boardPx + framePx;
   const totalHeight = boardPx + borderPx + framePx;
@@ -87,14 +93,14 @@ export async function generateBoardSVG(config) {
   );
   const fontSize = Math.round(Math.max(10, Math.min(480, borderPx * 0.72)));
   const fontFamily = "system-ui, -apple-system, 'Segoe UI', sans-serif";
-  const coordTextColor = darkSquare;
+  const coordTextColor = '#000000';
   const parts = [];
   parts.push(
     `<svg xmlns="http://www.w3.org/2000/svg" ` +
       `viewBox="0 0 ${totalWidth} ${totalHeight}" ` +
       `width="${totalWidth}" height="${totalHeight}">`
   );
-  if (withCoords && showCoordinateBorder) {
+  if (withBorder) {
     parts.push(
       `<rect x="${boardX - borderPx + (withFrame ? framePx / 2 : 0)}" y="${boardY}" ` +
         `width="${borderPx}" height="${boardPx}" fill="#ffffff"/>`
@@ -189,9 +195,9 @@ export async function downloadSVG(config, fileName, onProgress) {
       throw new Error('pieceImages is empty or missing');
     }
     const safeFileName = sanitizeFileName(fileName);
-    if (onProgress) onProgress(5);
+    if (onProgress) onProgress(5, 'Preparing');
     const svgString = await generateBoardSVG(config);
-    if (onProgress) onProgress(80);
+    if (onProgress) onProgress(80, 'SVG ready');
     const blob = new Blob([svgString], {
       type: 'image/svg+xml;charset=utf-8'
     });
@@ -201,7 +207,7 @@ export async function downloadSVG(config, fileName, onProgress) {
     link.download = safeFileName + '.svg';
     document.body.appendChild(link);
     link.click();
-    if (onProgress) onProgress(100);
+    if (onProgress) onProgress(100, 'Done');
     setTimeout(() => {
       if (document.body.contains(link)) document.body.removeChild(link);
       URL.revokeObjectURL(url);


### PR DESCRIPTION
This update keeps the existing project flow intact and makes a few practical improvements.\n\n- Reuses loaded chess piece images instead of loading them again in different screens.\n- Shows real export progress stages for PNG, JPEG, SVG, and batch export.\n- Keeps 24x and 32x export sizing more predictable with memory info for large exports.\n- Adds clearer FEN validation messages.\n- Adds a simple settings page for exporting, importing, and resetting local browser data.\n- Adds small FEN validation tests and updates the performance notes.\n\nChecks run:\n- pnpm test\n- pnpm lint\n- pnpm build\n- git diff --check\n\nLocal browser check: opened http://127.0.0.1:5173 successfully.