### PR TITLE
docs: rewrite ROADMAP as faithful v5.5.3 snapshot of master

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,135 +1,189 @@
-# Roadmap
+# ChessVision Roadmap — v5.5.3 (stable)
 
-Implemented features and planned work. No timeline commitments.
+This document describes the state of the **`master` branch at v5.5.3** and the maintenance posture for the v5.x line. It is intentionally a snapshot of what is in this branch today — not a forward-looking feature plan. Forward-looking work happens on `develop` and will be reflected here only after it has been merged and released on `master`.
+
+No timeline commitments are made or implied.
 
 ---
 
-## Implemented (v6.0.0)
+## 1. Release Posture
 
-### Core
+ChessVision v5.5.3 is the current stable release. The v5.5.x patch line is in **maintenance mode**: dependency hygiene, security patching, build/release infrastructure, and documentation refinement only. No new user-facing features will land on v5.5.x.
 
-- FEN notation parsing and validation (`MAX_FEN_LENGTH = 93`)
-- Canvas-based board renderer with coordinates
-- Interactive drag-and-drop board editor (React DnD, HTML5 + Touch backends)
-- Board flip and coordinate label toggle
-- 23 piece sets
-- 20+ preset board themes; up to 48 total presets including user-created ones
-- Custom board color picker (HSL/RGB/HEX)
-- Multiple color picker views (main, advanced, settings)
+The v5.5.0 → v5.5.3 patch series consisted of:
 
-### Export
+- **v5.5.0** — Branding consistency pass and release infrastructure
+- **v5.5.1** — Branding fixes, `RELEASES.md` history, SAST & logic review
+- **v5.5.2** — Dev-dependency batch and CI workflow refresh
+- **v5.5.3** — Final Dependabot batch
 
-- PNG and JPEG export with DPI metadata embedding
-- SVG export (Advanced FEN page: single and batch)
-- 4 quality levels: 8× (Print), 16× (Print), 24× (Social), 32× (Social)
-- Board size selection (4 cm, 6 cm, 8 cm) for print mode
-- Max export: 30,208 × 30,208 px at 9,600 DPI
-- Pause / resume / cancel export
-- Batch export with ZIP archive (Advanced FEN Input page)
+This pattern (chore-only patch releases) is the intended steady state for the v5.x line.
+
+---
+
+## 2. Implemented in v5.5.3
+
+The following capabilities are present and functional on the current `master` branch. They are inventoried directly from the source tree.
+
+### 2.1 Core Board
+
+- FEN notation parsing and validation (`MAX_FEN_LENGTH = 93`, enforced in `src/utils/validation.js` and `src/utils/fenParser.ts`)
+- Canvas-based board renderer with coordinate labels (`src/utils/canvasRenderer.js`)
+- Interactive drag-and-drop board editor built on `react-dnd` with `HTML5Backend` and `TouchBackend`
+- Board flip and coordinate-visibility toggles
+- Piece sets and theme presets (board palette + piece set selection)
+- Custom board color picker (HSV / RGB / HEX) with multiple picker views
+
+### 2.2 Export Pipeline
+
+- PNG and JPEG export via `canvasExporter.js`
+- DPI-correct export with physical-dimension targeting (cm → px conversion through `imageOptimizer.js`)
+- Multiple quality presets, board-size selection, and chunked main-thread export for large canvases (`advancedExport.js`)
+- ZIP-based batch export from the Advanced FEN Input page (`archiveManager.js`)
+- Pause / resume / cancel state machine for long-running exports
 - Clipboard copy
-- Web Worker-based SVG rasterization for exports above 4,000 px
+- Safari/iOS canvas-memory protection: explicit `canvas.width = 0` disposal after every blob generation
+- SVG board generation (`svgExporter.js`)
 
-### Pages and Routing
+### 2.3 Pages and Routing
 
-- Home page (`/`) — board playground and export studio
-- About page (`/about`)
-- Download / PWA install guide (`/download`)
-- Support page (`/support`)
-- Settings page (`/settings`) — export customization, theme studio, data management
-- FEN History page (`/fen-history`) — browsable history with archive
-- Advanced FEN Input page (`/advanced-fen`) — batch editor with playback
-- 404 page
-- All pages lazy-loaded with code splitting
+All routes are `React.lazy`-loaded with a `Suspense` fallback and animated with `framer-motion` `AnimatePresence`:
 
-### State and Persistence
+- `/` — Home (board playground, primary export entry point)
+- `/about`
+- `/download` (PWA install guide)
+- `/support`
+- `/settings` — tabbed: **Export Customization**, **Theme Customization**, **Data Management**
+- `/fen-history` — browsable history with filters, archive, and favorites
+- `/advanced-fen` — batch FEN editor with playback
+- `*` — 404
 
-- FEN history with localStorage persistence (300 ms debounced writes)
-- FEN history archive with auto-archival and freshness indicators (Fresh / Aging / Stale)
-- History filtering, sorting, favorites, and pinning
-- Recent colors list (up to 12)
-- Theme and settings persistence across sessions
-- FEN batch list persistence
+### 2.4 State and Persistence
 
-### Authentication and Cloud Sync
+- `FENBatchContext` — batch FEN list, persisted to `localStorage`
+- `ThemeSettingsContext` — theme preferences, recent colors, sound preferences
+- `LayoutContext` — UI layout state
+- `useFENHistory` — FEN history with 300 ms debounced `localStorage` writes
+- History archive with auto-archival, filtering, sorting, favorites, and pinning
+- All `localStorage` reads routed through `safeJSONParse` (no direct `JSON.parse` on untrusted strings)
+- **Local-only persistence.** v5.5.3 does not include cloud sync, user accounts, or any server-side data store.
 
-- Email/password sign-in with TOTP-based MFA
-- End-to-end encrypted cloud sync via Supabase
-- 90-day re-verification security gate (fail-closed)
-- Automatic localStorage → Supabase migration on first sign-in
-- Data management: export backup, restore from backup, full reset
+### 2.5 Data Management (Settings → Data Management)
 
-### App and UI
+- Export full app state to a JSON backup file
+- Restore from a backup file
+- Full local reset
+- All flows use `safeJSONParse` and `sanitizeFileName` at boundaries
 
-- Light / dark color-scheme toggle with `prefers-color-scheme` fallback
-- Skip-to-main-content link
-- Navbar hidden on tool pages for distraction-free editing
-- ErrorBoundary wrapping the full app
-- Toast notification system
-- PWA manifest
+### 2.6 Performance
 
-### Performance
-
-- `React.lazy` code splitting for all pages
-- `memo()` on `BoardSquare`, `DraggablePiece`, `DroppableSquare`
+- `React.memo` on board-render hot path (`BoardSquare`, `DraggablePiece`, `DroppableSquare`)
 - `useMemo` / `useCallback` on hot render paths
-- Piece image caching via `pieceImageCache.ts`
-- Virtualised FEN history list (`react-window`)
-- History persistence debounced at 300 ms
-- Export pause / resume / cancel with per-checkpoint cancellation hooks
-- Safari canvas OOM prevention: `canvas.width = 0` after every blob generation
+- Piece-image caching via `pieceImageCache.js`
+- Virtualized FEN history list (`react-window` + `react-window-infinite-loader`)
+- Per-page code splitting via `React.lazy`
+- Manual Vite chunking for vendor bundles (react, icons, motion, dnd, virtualization)
 
-### Code Quality
+### 2.7 Tooling and Release Engineering
 
-- TypeScript 6 strict mode across entire codebase
-- Centralised `logger.ts` (dev-only output)
-- Conventional commits enforced via commitlint + Husky
-- ESLint with react-hooks plugin, zero warnings in CI
-- Prettier with pre-commit hook
-
----
-
-## Not Yet Implemented
-
-### High Priority
-
-1. **SVG export on Home page** — SVG export is currently only in the Advanced FEN flow; parity with Home page export toolbar is pending.
-2. **URL-based position sharing** — `?fen=...` query param to load a position from a link.
-3. **Keyboard shortcuts** — Flip board, export, clear, copy, toggle coordinates.
-
-### Medium Priority
-
-- Undo / redo for interactive board edits
-- Arrow and highlight annotations on squares
-- PGN import
-- Game import from Lichess or Chess.com URL
-- Custom piece set upload
-
-### Low Priority / High Effort
-
-- Full WCAG 2.1 AA accessibility compliance
-- Board text description for screen readers (generated from parsed FEN)
-- Position database / famous games browser
-- i18n / multi-language support
+- pnpm 10 monorepo (`packageManager: pnpm@10.33.0`)
+- Vite 8, React 19, Tailwind 4, TypeScript 6 (mixed JS/TS — see § 3.1)
+- ESLint 9 with `eslint-plugin-react`, `eslint-plugin-react-hooks`, `eslint-plugin-react-refresh`; production lint gate at `--max-warnings=0`
+- Prettier, Husky pre-commit, `lint-staged`, commitlint with Conventional Commits
+- `semantic-release` configured against `master`
+- Testing: `node --test` against `src/utils/fenParser.test.js` (no experimental flags required)
+- CI on GitHub Actions; CodeQL extended-queries enabled
+- Dependabot configured for dependency PRs
 
 ---
 
-## Not Planned
+## 3. Known Limitations in v5.5.3
 
-- Move animation or game playback
-- Chess engine integration or position analysis
-- Native mobile apps
-- WebSocket multiplayer or real-time collaboration
+These are accurate, surveyed limitations of the v5.x line — not aspirational tasks. They inform what the next major release will need to address but are **not commitments** for v5.x patches.
+
+### 3.1 Mixed JavaScript / TypeScript
+
+The v5.x source tree is predominantly `.jsx` / `.js` with a small TypeScript footprint (notably `fenParser.ts`, `fenValidationDetailed.ts`, `useDebouncedFENValidation.ts`). The repo's `tsconfig` and ESLint configuration target both, but TypeScript coverage is partial. Full migration is a v6.x-scope concern.
+
+### 3.2 Test Coverage
+
+Automated test coverage is limited to FEN parser unit tests (`src/utils/fenParser.test.js`). Component and integration testing are not present in v5.5.3.
+
+### 3.3 Export Pipeline
+
+- Very-large exports (24× / 32× Social presets, multi-cm canvases) execute on the main thread via chunked rendering in `advancedExport.js`. There is no Web Worker / `OffscreenCanvas` raster path in v5.x.
+- Safari and iOS WebKit can OOM on the largest canvas sizes despite the explicit `canvas.width = 0` disposal pattern. This is a platform limitation that the v5.x pipeline mitigates but does not eliminate.
+
+### 3.4 Accessibility
+
+- The canvas-rendered board has no DOM-equivalent representation for screen readers.
+- No board text description is generated from the parsed FEN.
+- Full WCAG 2.1 AA conformance is not claimed for v5.5.3.
+
+### 3.5 Persistence Scope
+
+v5.5.3 persistence is `localStorage` only. There is no authentication, no server-side data, no cross-device sync, and no end-to-end encryption surface. Data Management's backup/restore is the only mechanism for moving state between devices.
+
+### 3.6 Build and Bundle Observability
+
+- No Lighthouse CI integration.
+- No automated bundle-size regression tracking in the build pipeline.
+- Manual `pnpm build:analyze` (vite-bundle-visualizer) is the supported inspection path.
+
+### 3.7 Filesystem Artefact
+
+Case-insensitive-filesystem residue exists in `src/components/features/`: directory pairs such as `export/` / `Export/`, `fen/` / `Fen/`, `history/` / `History/` coexist. Treated as cosmetic in v5.x; resolution deferred.
 
 ---
 
-## Known Technical Debt
+## 4. Maintenance Policy for the v5.x Line
 
-- Canvas board has no DOM accessible alternative for screen readers
-- Automated test coverage is limited to FEN parser unit tests
-- 24×/32× Social exports may crash on Safari/iOS (canvas memory cap)
-- No Lighthouse CI or bundle size tracking in the build pipeline
-- Case-insensitive filesystem artefact: `export/` and `Export/` directories coexist in `features/`; same for `fen/`/`Fen/`, `history/`/`History/`
+### 4.1 In scope for v5.5.x patch releases
+
+- Security patches (dependency CVEs, SAST findings)
+- Dependabot dependency bumps for direct dependencies
+- Documentation corrections, typos, link rot
+- CI / release-pipeline fixes
+- Build-config fixes that do not alter user-facing behavior
+
+### 4.2 Not in scope for v5.5.x patch releases
+
+- New user-facing features
+- Schema or API changes
+- Breaking changes to `localStorage` keys, FEN history format, or settings shape
+- TypeScript migration of additional files
+- Performance refactors that change observable behavior
+
+### 4.3 Bug-fix policy
+
+- **Crash-class** bugs (canvas OOM workarounds, regression in export, navigation crashes): backported to `master` as a v5.5.x patch.
+- **Functional** bugs that do not crash or destroy data: triaged; routine fixes ship in the next minor; non-routine fixes are deferred to the next major.
+- **Cosmetic / polish** issues: deferred to the next major unless trivial.
+
+### 4.4 Supply-chain hygiene
+
+- Dependabot PRs are reviewed and merged in batches (see v5.5.2 / v5.5.3 changelog entries).
+- Major-version bumps of direct dependencies are evaluated individually and may be deferred to the next major.
+- `semantic-release` operates against `master`; tags and GitHub Releases are authored automatically from Conventional Commits.
+
+### 4.5 Branch model
+
+- `master` — stable; receives only the changes described in § 4.1.
+- `develop` — active development; the next major's surface area accumulates here.
+- Feature branches target `develop`. Patch branches against the v5.x line target `master` directly (chore / fix scope only).
 
 ---
 
-*Last updated: May 2026 — v6.0.0*
+## 5. Out of Scope (v5.x)
+
+The following are explicitly out of scope for the entire v5.x line. They may be considered for a future major release but carry no commitment here:
+
+- Move animation, game playback, or PGN replay
+- Chess-engine integration or position analysis
+- Native mobile applications
+- Multiplayer, real-time collaboration, or WebSocket transport
+- i18n / localisation
+
+---
+
+*This roadmap reflects `master` at v5.5.3. It will be revised when the next merge to `master` lands.*


### PR DESCRIPTION
## Summary

Replaces the `ROADMAP.md` introduced in #88 with a faithful snapshot of the `master` branch at **v5.5.3**.

The previous roadmap was drafted from the `develop` branch's feature surface (auth, MFA, end-to-end-encrypted cloud sync, Web Worker SVG rasterization). None of those capabilities exist on `master`. Publishing them on the stable branch's roadmap misrepresented the state of the shipped product.

## What this PR changes

- `ROADMAP.md` — complete rewrite. New structure:
  1. **Release Posture** — explicitly positions the v5.5.x line as maintenance mode and reviews the v5.5.0 → v5.5.3 patch series.
  2. **Implemented in v5.5.3** — capabilities inventoried directly from the source tree (`src/utils/`, `src/pages/`, `src/components/`, `src/contexts/`, `package.json`).
  3. **Known Limitations** — documented as surveyed facts (mixed JS/TS, test coverage gap, main-thread export path, accessibility gap, local-only persistence, build observability, case-insensitive-filesystem residue).
  4. **Maintenance Policy** — written policy for the v5.x line covering in-scope patch changes, out-of-scope changes, bug-fix triage, supply-chain hygiene, and the branch model.
  5. **Out of Scope (v5.x)** — explicit non-goals for the v5.x line.

## What this PR does not change

- No source code, build configuration, or test files are touched.
- No `develop`-branch features are described as available on `master`.
- No timeline commitments are introduced.

## Rationale

The roadmap on `master` should describe what `master` is. Forward-looking work belongs in a roadmap that ships alongside the code, not ahead of it. When the next major merges to `master`, this document will be revised against the new state of the branch.

## Test plan

- [x] Inventory matches `master @ bf99e20`: pages enumerated from `src/pages/`, utilities from `src/utils/`, contexts from `src/contexts/`, dependencies from `package.json`, version from `package.json` (`5.5.3`), release history from `CHANGELOG.md`.
- [x] No claims made about features absent from the source tree (no `src/features/auth/`, no `svgRasterWorker`, no Supabase dependency).
- [x] Cross-reference at `docs/README.md` continues to resolve (`../ROADMAP.md`, unchanged from #88).
- [x] No source code touched — existing CI gates (lint, typecheck, fenParser tests) remain unaffected.