### PR TITLE
fix: enforce no-console lint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,10 +65,7 @@ export default [
         }
       ],
 
-      'no-console':
-        process.env.NODE_ENV === 'production'
-          ? ['error', { allow: ['log', 'warn', 'error'] }]
-          : 'off',
+      'no-console': 'error',
 
       'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
 
@@ -134,16 +131,20 @@ export default [
         }
       ],
 
-      'no-console':
-        process.env.NODE_ENV === 'production'
-          ? ['error', { allow: ['log', 'warn', 'error'] }]
-          : 'off',
+      'no-console': 'error',
 
       'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
 
       'no-var': 'error',
       'prefer-const': 'warn',
       eqeqeq: ['error', 'always', { null: 'ignore' }]
+    }
+  },
+
+  {
+    files: ['src/utils/logger.js'],
+    rules: {
+      'no-console': ['error', { allow: ['log', 'warn', 'error'] }]
     }
   }
 ];


### PR DESCRIPTION
Fixes #87

## Changes
- Make `no-console` an error for normal JS and TS source linting instead of only checking it when `NODE_ENV=production` is set.
- Keep a narrow exception for `src/utils/logger.js`, since that file is the dev-only wrapper that the rest of the app is supposed to use.

## Verification
- `pnpm lint`
- `pnpm build`
- `pnpm exec prettier --check eslint.config.js`
- ESLint API smoke check: linting `console.log(leak)` as `src/tmp-console-check.js` reports `no-console` as an error.

Small note: `pnpm test` is currently blocked on `src/utils/fenParser.test.js` importing `fenParser.js` while the source file on `master` is `fenParser.ts`, so I didn't treat that as part of this config-only change.