### PR TITLE
fix: release temporary export canvases

### DIFF
--- a/src/utils/advancedExport.js
+++ b/src/utils/advancedExport.js
@@ -14,10 +14,14 @@ export async function progressiveExport(config, fileName, format) {
     format = 'png';
   }
   const canvas = await createSmartCanvas(config);
-  if (canvas.width > 8192 || canvas.height > 8192) {
-    return await chunkedExport(canvas, fileName, format);
+  try {
+    if (canvas.width > 8192 || canvas.height > 8192) {
+      return await chunkedExport(canvas, fileName, format);
+    }
+    return await standardExport(canvas, fileName, format);
+  } finally {
+    releaseCanvas(canvas);
   }
-  return await standardExport(canvas, fileName, format);
 }
 
 async function createSmartCanvas(config) {
@@ -45,7 +49,11 @@ async function chunkedExport(canvas, fileName, format) {
   smallerCanvas.height = canvas.height * scale;
   const ctx = smallerCanvas.getContext('2d');
   ctx.drawImage(canvas, 0, 0, smallerCanvas.width, smallerCanvas.height);
-  return await standardExport(smallerCanvas, fileName, format);
+  try {
+    return await standardExport(smallerCanvas, fileName, format);
+  } finally {
+    releaseCanvas(smallerCanvas);
+  }
 }
 async function standardExport(canvas, fileName, format) {
   let mimeType = 'image/png';
@@ -57,26 +65,37 @@ async function standardExport(canvas, fileName, format) {
     quality = 0.98;
   }
   return new Promise(function (resolve, reject) {
-    canvas.toBlob(
-      function (blob) {
-        if (!blob) {
-          reject(new Error('Failed to create ' + format + ' blob'));
-          return;
-        }
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = fileName + '.' + extension;
-        document.body.appendChild(link);
-        link.click();
-        setTimeout(function () {
-          document.body.removeChild(link);
-          URL.revokeObjectURL(url);
-          resolve();
-        }, 100);
-      },
-      mimeType,
-      quality
-    );
+    try {
+      canvas.toBlob(
+        function (blob) {
+          if (!blob) {
+            reject(new Error('Failed to create ' + format + ' blob'));
+            return;
+          }
+          const url = URL.createObjectURL(blob);
+          const link = document.createElement('a');
+          link.href = url;
+          link.download = fileName + '.' + extension;
+          document.body.appendChild(link);
+          link.click();
+          setTimeout(function () {
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+            resolve();
+          }, 100);
+        },
+        mimeType,
+        quality
+      );
+    } catch (error) {
+      reject(error);
+    }
   });
+}
+
+function releaseCanvas(canvas) {
+  if (canvas) {
+    canvas.width = 0;
+    canvas.height = 0;
+  }
 }

--- a/src/utils/svgExporter.js
+++ b/src/utils/svgExporter.js
@@ -26,9 +26,10 @@ function getPieceKey(fenPiece) {
  */
 async function imageToDataURL(img) {
   return new Promise((resolve) => {
+    let canvas = null;
     try {
       const size = Math.max(img.naturalWidth || 64, img.naturalHeight || 64, 1);
-      const canvas = document.createElement('canvas');
+      canvas = document.createElement('canvas');
       canvas.width = size;
       canvas.height = size;
       const ctx = canvas.getContext('2d');
@@ -37,6 +38,11 @@ async function imageToDataURL(img) {
     } catch (err) {
       logger.warn('SVG export: failed to convert piece image to base64:', err);
       resolve('');
+    } finally {
+      if (canvas) {
+        canvas.width = 0;
+        canvas.height = 0;
+      }
     }
   });
 }


### PR DESCRIPTION
Fixes #79
Fixes #80

## Changes
- Release the main progressive export canvas after PNG/JPEG encoding finishes.
- Release the downscaled chunk canvas after it has been handed through the normal export path.
- Release the small per-piece canvas used while inlining piece images for SVG export.

## Verification
- `pnpm exec prettier --check src/utils/advancedExport.js src/utils/svgExporter.js`
- `pnpm lint`
- `pnpm build`
- `git diff --check HEAD~1..HEAD`

I also ran `pnpm test`; it still hits the existing `fenParser.js` vs `fenParser.ts` import issue on current `master`, so I left that out of the pass list rather than pretending this PR affects it.