### PR TITLE
fix: run FEN parser tests through stable bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/.tmp
 
 # production
 /build

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,7 @@ import globals from 'globals';
 
 export default [
   {
-    ignores: ['build/', 'dist/', 'node_modules/']
+    ignores: ['build/', 'dist/', '.tmp/', 'node_modules/']
   },
 
   js.configs.recommended,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",
     "lint:ci": "eslint . --max-warnings=500",
-    "test": "node --test src/utils/fenParser.test.js",
+    "test": "esbuild src/utils/fenParser.test.js --bundle --platform=node --format=esm --outfile=.tmp/node-tests/fenParser.test.mjs && node --test .tmp/node-tests/fenParser.test.mjs",
     "format": "prettier --write \"src/**/*.{js,jsx,json,css,md}\"",
     "format:check": "prettier . --check",
     "format:ci": "prettier . --check || exit 0",


### PR DESCRIPTION
Fixes #82

## Changes
- Bundle the FEN parser test with esbuild before running `node --test`, so Node no longer has to load TypeScript directly or look for a generated JS sibling that is not in the repo.
- Ignore the generated `.tmp/` test output in Git and ESLint.

## Verification
- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm exec prettier --check --ignore-unknown .gitignore package.json eslint.config.js`
- `git diff --check`

One note: `pnpm format:check` still reports existing formatting drift in unrelated files on current `master`, so I used the touched-files Prettier check above for this PR.