### PR TITLE
fix: route localStorage reads through safe parser

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -67,6 +67,22 @@ export default [
 
       'no-console': 'error',
 
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.object.name='localStorage'][callee.property.name='getItem']",
+          message:
+            'Use getStoredValue/getStoredString from src/utils/validation.js for localStorage reads.'
+        },
+        {
+          selector:
+            "CallExpression[callee.object.property.name='localStorage'][callee.property.name='getItem']",
+          message:
+            'Use getStoredValue/getStoredString from src/utils/validation.js for localStorage reads.'
+        }
+      ],
+
       'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
 
       'no-var': 'error',
@@ -133,11 +149,41 @@ export default [
 
       'no-console': 'error',
 
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.object.name='localStorage'][callee.property.name='getItem']",
+          message:
+            'Use getStoredValue/getStoredString from src/utils/validation.js for localStorage reads.'
+        },
+        {
+          selector:
+            "CallExpression[callee.object.property.name='localStorage'][callee.property.name='getItem']",
+          message:
+            'Use getStoredValue/getStoredString from src/utils/validation.js for localStorage reads.'
+        }
+      ],
+
       'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'warn',
 
       'no-var': 'error',
       'prefer-const': 'warn',
       eqeqeq: ['error', 'always', { null: 'ignore' }]
+    }
+  },
+
+  {
+    files: ['src/utils/validation.js'],
+    rules: {
+      'no-restricted-syntax': 'off'
+    }
+  },
+
+  {
+    files: ['public/theme-init.js'],
+    rules: {
+      'no-restricted-syntax': 'off'
     }
   },
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { ErrorBoundary } from '@/components/ui';
 import { FENBatchProvider, ThemeSettingsProvider } from '@/contexts';
 import Routes from '@/routes/Router';
 import { logger } from '@/utils/logger';
+import { getStoredString } from '@/utils/validation';
 
 declare global {
   interface Window {
@@ -68,7 +69,7 @@ function getInitialTheme(): Theme {
   }
 
   try {
-    const saved = localStorage.getItem('chess-theme');
+    const saved = getStoredString('chess-theme', '');
     if (saved && VALID_THEMES.has(saved)) {
       return saved as Theme;
     }
@@ -117,7 +118,7 @@ function App() {
 
     function handleMediaChange(event: MediaQueryListEvent) {
       try {
-        const manualOverride = localStorage.getItem('chess-theme');
+        const manualOverride = getStoredString('chess-theme', '');
         if (!manualOverride) {
           setTheme(event.matches ? 'dark' : 'light');
         }

--- a/src/components/features/ClipboardHistory/ClipboardHistory.jsx
+++ b/src/components/features/ClipboardHistory/ClipboardHistory.jsx
@@ -3,7 +3,7 @@ import { Check, Copy, Trash2, X } from 'lucide-react';
 import { List } from 'react-window';
 
 import { logger } from '@/utils/logger';
-import { safeJSONParse } from '@/utils/validation';
+import { getStoredValue } from '@/utils/validation';
 
 /**
  * @param {Object} props
@@ -90,8 +90,7 @@ const ClipboardHistory = memo(function ClipboardHistory({
 
   const loadHistory = useCallback(() => {
     try {
-      const saved = localStorage.getItem('fenClipboardHistory');
-      const history = safeJSONParse(saved, []);
+      const history = getStoredValue('fenClipboardHistory', []);
       setClipboardHistory(Array.isArray(history) ? history : []);
     } catch {
       setClipboardHistory([]);

--- a/src/components/features/ColorPicker/views/ThemeSettingsView.jsx
+++ b/src/components/features/ColorPicker/views/ThemeSettingsView.jsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Eye, Grid3X3, RotateCcw, Zap } from 'lucide-react';
 
 import { logger } from '@/utils/logger';
-import { safeJSONParse } from '@/utils/validation';
+import { getStoredValue } from '@/utils/validation';
 
 const STORAGE_KEY = 'chess-vision-settings';
 
@@ -16,8 +16,7 @@ const STORAGE_KEY = 'chess-vision-settings';
 function ThemeSettingsView({ onSettingsChange }) {
   const [settings, setSettings] = useState(() => {
     try {
-      const saved = localStorage.getItem(STORAGE_KEY);
-      const parsed = safeJSONParse(saved, null);
+      const parsed = getStoredValue(STORAGE_KEY, null);
       return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
         ? parsed
         : {

--- a/src/components/features/Fen/FENInputField/FENInputField.tsx
+++ b/src/components/features/Fen/FENInputField/FENInputField.tsx
@@ -22,7 +22,7 @@ import { useFENBatch } from '@/contexts';
 import { useDebouncedFENValidation } from '@/hooks/useDebouncedFENValidation';
 import { validateFEN } from '@/utils';
 import { logger } from '@/utils/logger';
-import { MAX_FEN_LENGTH, safeJSONParse } from '@/utils/validation';
+import { getStoredValue, MAX_FEN_LENGTH } from '@/utils/validation';
 
 export type NotificationType = 'success' | 'error' | 'warning' | 'info';
 
@@ -114,10 +114,7 @@ const FENInputField = memo(
     // ── Favorites check ──
     useEffect(() => {
       try {
-        const rawFavorites = safeJSONParse(
-          localStorage.getItem('favoriteFens'),
-          {}
-        );
+        const rawFavorites = getStoredValue('favoriteFens', {});
         if (isRecord(rawFavorites)) {
           setIsFavorite(!!rawFavorites[fen]);
         } else {
@@ -135,10 +132,7 @@ const FENInputField = memo(
         const currentFen = localFen.trim();
         if (currentFen && validateFEN(currentFen)) {
           try {
-            const rawHistory = safeJSONParse(
-              localStorage.getItem('fenClipboardHistory'),
-              []
-            );
+            const rawHistory = getStoredValue('fenClipboardHistory', []);
 
             const history: FENHistoryEntry[] = Array.isArray(rawHistory)
               ? rawHistory.filter(
@@ -203,10 +197,7 @@ const FENInputField = memo(
       }
 
       try {
-        const rawFavorites = safeJSONParse(
-          localStorage.getItem('favoriteFens'),
-          {}
-        );
+        const rawFavorites = getStoredValue('favoriteFens', {});
 
         const favorites: Record<string, boolean> = {};
         if (isRecord(rawFavorites)) {

--- a/src/contexts/FENBatchContext.jsx
+++ b/src/contexts/FENBatchContext.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { validateFEN } from '@/utils';
-import { safeJSONParse } from '@/utils/validation';
+import { getStoredValue } from '@/utils/validation';
 import { FENBatchContext } from './FENBatchStore';
 
 /**
@@ -13,8 +13,7 @@ import { FENBatchContext } from './FENBatchStore';
 export function FENBatchProvider({ children }) {
   const [batchList, setBatchList] = useState(() => {
     try {
-      const saved = localStorage.getItem('fenBatchList');
-      const parsed = safeJSONParse(saved, null);
+      const parsed = getStoredValue('fenBatchList', null);
       return Array.isArray(parsed) ? parsed : [];
     } catch {
       return [];

--- a/src/contexts/ThemeSettingsContext.jsx
+++ b/src/contexts/ThemeSettingsContext.jsx
@@ -7,7 +7,7 @@ import {
   useState
 } from 'react';
 
-import { safeJSONParse } from '@/utils/validation';
+import { getStoredValue } from '@/utils/validation';
 
 const ThemeSettingsContext = createContext(null);
 
@@ -60,8 +60,7 @@ const defaultSettings = {
 export function ThemeSettingsProvider({ children }) {
   const [settings, setSettings] = useState(() => {
     try {
-      const saved = localStorage.getItem('themeSettings');
-      const parsed = safeJSONParse(saved, null);
+      const parsed = getStoredValue('themeSettings', null);
       return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
         ? { ...defaultSettings, ...parsed }
         : defaultSettings;
@@ -72,8 +71,7 @@ export function ThemeSettingsProvider({ children }) {
 
   const [recentColors, setRecentColors] = useState(() => {
     try {
-      const saved = localStorage.getItem('recentColors');
-      const parsed = safeJSONParse(saved, null);
+      const parsed = getStoredValue('recentColors', null);
       return Array.isArray(parsed) ? parsed : [];
     } catch {
       return [];

--- a/src/hooks/useFENHistory.js
+++ b/src/hooks/useFENHistory.js
@@ -16,7 +16,7 @@ import {
   touchEntry
 } from '@/utils/historyUtils';
 import { logger } from '@/utils/logger';
-import { safeJSONParse } from '@/utils/validation';
+import { getStoredValue, safeJSONParse } from '@/utils/validation';
 
 const DRAG_INACTIVITY_TIMEOUT = 60000;
 
@@ -79,8 +79,7 @@ export function useFENHistory(fen, onFavoriteStatusChange) {
         }
 
         if (!data) {
-          const local = window.localStorage.getItem('fen-history');
-          if (local) data = safeJSONParse(local, null);
+          data = getStoredValue('fen-history', null);
         }
 
         if (Array.isArray(data) && isMountedRef.current) {

--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { logger } from '@/utils/logger';
-import { safeJSONParse } from '@/utils/validation';
+import { getStoredValue, safeJSONParse } from '@/utils/validation';
 
 /**
  * Persists state to localStorage with debounced writes.
@@ -18,8 +18,7 @@ export function useLocalStorage(key, initialValue) {
       return initialValue;
     }
     try {
-      const item = window.localStorage.getItem(key);
-      return item ? safeJSONParse(item, initialValue) : initialValue;
+      return getStoredValue(key, initialValue);
     } catch (error) {
       logger.error(`Error loading ${key} from localStorage:`, error);
       return initialValue;
@@ -122,12 +121,9 @@ export function useHybridStorage(key, initialValue, useCloudStorage = false) {
             }
           }
         }
-        const item = window.localStorage.getItem(key);
-        if (item) {
-          const parsed = safeJSONParse(item, null);
-          if (parsed !== null) {
-            setStoredValue(parsed);
-          }
+        const parsed = getStoredValue(key, null);
+        if (parsed !== null) {
+          setStoredValue(parsed);
         }
       } catch (error) {
         logger.error(`Error loading ${key}:`, error);

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,7 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { logger } from '@/utils/logger';
-import { safeJSONParse, sanitizeHexColor } from '@/utils/validation';
+import {
+  getStoredString,
+  getStoredValue,
+  safeJSONParse,
+  sanitizeHexColor
+} from '@/utils/validation';
 
 /**
  * Manages board theme colors, presets, and persistence.
@@ -36,27 +41,20 @@ export function useTheme({
           }
         }
 
-        const lightLocal = window.localStorage.getItem('chess-light-square');
-        const darkLocal = window.localStorage.getItem('chess-dark-square');
+        const lightLocal = getStoredString('chess-light-square', '');
+        const darkLocal = getStoredString('chess-dark-square', '');
 
         if (lightLocal || darkLocal) {
-          setLightSquare(
-            sanitizeHexColor(lightLocal?.replace(/"/g, ''), initialLight)
-          );
-          setDarkSquare(
-            sanitizeHexColor(darkLocal?.replace(/"/g, ''), initialDark)
-          );
+          setLightSquare(sanitizeHexColor(lightLocal, initialLight));
+          setDarkSquare(sanitizeHexColor(darkLocal, initialDark));
           return;
         }
 
-        const localTheme = window.localStorage.getItem('chess-theme');
-        if (localTheme) {
-          const saved = safeJSONParse(localTheme, null);
-          if (saved && typeof saved === 'object') {
-            setLightSquare(sanitizeHexColor(saved.light, initialLight));
-            setDarkSquare(sanitizeHexColor(saved.dark, initialDark));
-            setCurrentTheme('custom');
-          }
+        const saved = getStoredValue('chess-theme', null);
+        if (saved && typeof saved === 'object') {
+          setLightSquare(sanitizeHexColor(saved.light, initialLight));
+          setDarkSquare(sanitizeHexColor(saved.dark, initialDark));
+          setCurrentTheme('custom');
         }
       } catch (err) {
         logger.error('Failed to load theme:', err);
@@ -65,12 +63,9 @@ export function useTheme({
 
     const loadHistory = () => {
       try {
-        const historyData = window.localStorage.getItem('theme-history');
-        if (historyData) {
-          const parsed = safeJSONParse(historyData, null);
-          if (Array.isArray(parsed)) {
-            setThemeHistory(parsed);
-          }
+        const parsed = getStoredValue('theme-history', null);
+        if (Array.isArray(parsed)) {
+          setThemeHistory(parsed);
         }
       } catch (err) {
         logger.error('Failed to load theme history:', err);
@@ -81,14 +76,14 @@ export function useTheme({
     loadHistory();
 
     const handleStorageChange = () => {
-      const light = window.localStorage.getItem('chess-light-square');
-      const dark = window.localStorage.getItem('chess-dark-square');
+      const light = getStoredString('chess-light-square', '');
+      const dark = getStoredString('chess-dark-square', '');
 
       if (light) {
-        setLightSquare(sanitizeHexColor(light.replace(/"/g, ''), initialLight));
+        setLightSquare(sanitizeHexColor(light, initialLight));
       }
       if (dark) {
-        setDarkSquare(sanitizeHexColor(dark.replace(/"/g, ''), initialDark));
+        setDarkSquare(sanitizeHexColor(dark, initialDark));
       }
     };
 
@@ -357,12 +352,9 @@ export function useThemePresets() {
 
   useEffect(() => {
     try {
-      const saved = window.localStorage.getItem('custom-theme-presets');
-      if (saved) {
-        const parsed = safeJSONParse(saved, null);
-        if (Array.isArray(parsed)) {
-          setCustomPresets(parsed);
-        }
+      const parsed = getStoredValue('custom-theme-presets', null);
+      if (Array.isArray(parsed)) {
+        setCustomPresets(parsed);
       }
     } catch (err) {
       logger.error('Failed to load custom presets:', err);

--- a/src/pages/AdvancedFENInputPage/AdvancedFENInputPage.jsx
+++ b/src/pages/AdvancedFENInputPage/AdvancedFENInputPage.jsx
@@ -20,7 +20,7 @@ import {
   resumeExport,
   validateFEN
 } from '@/utils';
-import { MAX_FEN_LENGTH, safeJSONParse } from '@/utils/validation';
+import { getStoredValue, MAX_FEN_LENGTH } from '@/utils/validation';
 
 import BoardDisplay from './BoardDisplay';
 import PlaybackControls from './PlaybackControls';
@@ -80,8 +80,7 @@ const AdvancedFENInputPage = memo(function AdvancedFENInputPage({
     return arr;
   }, [batchList]);
   const [favorites, setFavorites] = useState(() => {
-    const saved = localStorage.getItem(STORAGE_KEYS.FAVORITES);
-    const parsed = safeJSONParse(saved, null);
+    const parsed = getStoredValue(STORAGE_KEYS.FAVORITES, null);
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
       ? parsed
       : {};
@@ -95,8 +94,7 @@ const AdvancedFENInputPage = memo(function AdvancedFENInputPage({
   const [duplicateWarning, setDuplicateWarning] = useState(null);
   const [activeTab, setActiveTab] = useState(TABS.POSITIONS);
   const [positionSettings, setPositionSettings] = useState(() => {
-    const saved = localStorage.getItem('advanced-fen-position-settings');
-    const parsed = safeJSONParse(saved, null);
+    const parsed = getStoredValue('advanced-fen-position-settings', null);
     return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
       ? parsed
       : {};

--- a/src/pages/FENHistoryPage.jsx
+++ b/src/pages/FENHistoryPage.jsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/features/History';
 import { useFENHistory } from '@/hooks';
 import { logger } from '@/utils/logger';
+import { getStoredBoolean, getStoredString } from '@/utils/validation';
 
 /**
  * Full-page FEN history manager with tabs for active entries, favorites, and archive.
@@ -31,7 +32,7 @@ const FENHistoryPage = memo(function FENHistoryPage() {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteTargetId, setDeleteTargetId] = useState(null);
   const [doNotAskAgain, setDoNotAskAgain] = useState(() => {
-    return localStorage.getItem('fen-history-skip-delete-confirm') === 'true';
+    return getStoredBoolean('fen-history-skip-delete-confirm', false);
   });
 
   const {
@@ -62,28 +63,21 @@ const FENHistoryPage = memo(function FENHistoryPage() {
     setArchiveFiltersHook(archiveFilters);
   }, [archiveFilters, setArchiveFiltersHook]);
 
-  const [lightSquare, setLightSquare] = useState(
-    () =>
-      localStorage.getItem('chess-light-square')?.replace(/"/g, '') || '#f0d9b5'
+  const [lightSquare, setLightSquare] = useState(() =>
+    getStoredString('chess-light-square', '#f0d9b5')
   );
-  const [darkSquare, setDarkSquare] = useState(
-    () =>
-      localStorage.getItem('chess-dark-square')?.replace(/"/g, '') || '#b58863'
+  const [darkSquare, setDarkSquare] = useState(() =>
+    getStoredString('chess-dark-square', '#b58863')
   );
-  const [pieceStyle, setPieceStyle] = useState(
-    () =>
-      localStorage.getItem('chess-piece-style')?.replace(/"/g, '') || 'cburnett'
+  const [pieceStyle, setPieceStyle] = useState(() =>
+    getStoredString('chess-piece-style', 'cburnett')
   );
 
   useEffect(() => {
     const handleStorageChange = () => {
-      const light = localStorage.getItem('chess-light-square');
-      const dark = localStorage.getItem('chess-dark-square');
-      const style = localStorage.getItem('chess-piece-style');
-
-      setLightSquare(light?.replace(/"/g, '') || '#f0d9b5');
-      setDarkSquare(dark?.replace(/"/g, '') || '#b58863');
-      setPieceStyle(style?.replace(/"/g, '') || 'cburnett');
+      setLightSquare(getStoredString('chess-light-square', '#f0d9b5'));
+      setDarkSquare(getStoredString('chess-dark-square', '#b58863'));
+      setPieceStyle(getStoredString('chess-piece-style', 'cburnett'));
     };
 
     handleStorageChange();

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -21,7 +21,7 @@ import {
   shouldForceCoordinateBorder,
   validateFEN
 } from '@/utils';
-import { safeJSONParse, sanitizeHexColor } from '@/utils/validation';
+import { getStoredString, sanitizeHexColor } from '@/utils/validation';
 
 /**
  * Export state reducer - PERFORMANCE OPTIMIZED
@@ -105,26 +105,14 @@ function HomePage() {
 
   useEffect(() => {
     const handleStorageChange = () => {
-      const light = localStorage.getItem('chess-light-square');
-      const dark = localStorage.getItem('chess-dark-square');
+      const light = getStoredString('chess-light-square', '');
+      const dark = getStoredString('chess-dark-square', '');
 
       if (light) {
-        try {
-          const parsed = safeJSONParse(light, null);
-          const color = typeof parsed === 'string' ? parsed : light;
-          setLightSquare(sanitizeHexColor(color, '#f0d9b5'));
-        } catch {
-          setLightSquare(sanitizeHexColor(light, '#f0d9b5'));
-        }
+        setLightSquare(sanitizeHexColor(light, '#f0d9b5'));
       }
       if (dark) {
-        try {
-          const parsed = safeJSONParse(dark, null);
-          const color = typeof parsed === 'string' ? parsed : dark;
-          setDarkSquare(sanitizeHexColor(color, '#b58863'));
-        } catch {
-          setDarkSquare(sanitizeHexColor(dark, '#b58863'));
-        }
+        setDarkSquare(sanitizeHexColor(dark, '#b58863'));
       }
     };
 

--- a/src/pages/settings/DataManagement.jsx
+++ b/src/pages/settings/DataManagement.jsx
@@ -2,7 +2,7 @@ import { memo, useRef, useState } from 'react';
 
 import { Download, RotateCcw, Upload } from 'lucide-react';
 
-import { safeJSONParse } from '@/utils/validation';
+import { getStoredBackupValue, safeJSONParse } from '@/utils/validation';
 
 const STORAGE_KEYS = [
   'chess-fen',
@@ -35,7 +35,7 @@ const DataManagement = memo(function DataManagement() {
   function handleExportData() {
     const data = {};
     STORAGE_KEYS.forEach((key) => {
-      const value = localStorage.getItem(key);
+      const value = getStoredBackupValue(key);
       if (value !== null) {
         data[key] = value;
       }

--- a/src/utils/archiveManager.js
+++ b/src/utils/archiveManager.js
@@ -5,7 +5,7 @@ import {
   sortArchivedByArchiveDate
 } from './historyUtils';
 import { logger } from './logger';
-import { safeJSONParse } from './validation';
+import { getStoredValue, safeJSONParse } from './validation';
 
 const ARCHIVE_STORAGE_KEY = 'fen-history-archive';
 const MAX_ARCHIVE_SIZE = 10000;
@@ -28,11 +28,8 @@ export async function loadArchive() {
     logger.log('Cloud storage not available for archive');
   }
   try {
-    const localData = window.localStorage.getItem(ARCHIVE_STORAGE_KEY);
-    if (localData) {
-      const parsed = safeJSONParse(localData, null);
-      if (Array.isArray(parsed)) return parsed;
-    }
+    const parsed = getStoredValue(ARCHIVE_STORAGE_KEY, null);
+    if (Array.isArray(parsed)) return parsed;
   } catch (err) {
     logger.error('Failed to load archive:', err);
   }
@@ -169,10 +166,7 @@ export function getArchiveStatistics(archive) {
  */
 export async function performAutoArchival() {
   try {
-    const historyData = window.localStorage.getItem('fen-history');
-    if (!historyData) return { entries: [], archive: [], archivedCount: 0 };
-
-    const activeEntries = safeJSONParse(historyData, null);
+    const activeEntries = getStoredValue('fen-history', null);
     if (!Array.isArray(activeEntries)) {
       return { entries: [], archive: [], archivedCount: 0 };
     }

--- a/src/utils/themeCustomization.js
+++ b/src/utils/themeCustomization.js
@@ -5,7 +5,7 @@ import {
   STORAGE_KEYS,
   WOOD_PRESET
 } from '@/constants';
-import { safeJSONParse } from '@/utils/validation';
+import { getStoredString, getStoredValue } from '@/utils/validation';
 
 /**
  * Builds the default preset list from built-in board themes.
@@ -45,9 +45,8 @@ function normalizePresets(presets) {
  */
 export function loadPresets() {
   try {
-    const raw = localStorage.getItem(STORAGE_KEYS.PRESETS);
-    if (raw) {
-      const loaded = safeJSONParse(raw);
+    const loaded = getStoredValue(STORAGE_KEYS.PRESETS, null);
+    if (loaded) {
       return normalizePresets(loaded);
     }
   } catch {
@@ -79,8 +78,7 @@ export function savePresets(presets) {
  */
 export function readSquare(key, fallback) {
   try {
-    const v = localStorage.getItem(key);
-    return v ? v.replace(/"/g, '') : fallback;
+    return getStoredString(key, fallback);
   } catch {
     return fallback;
   }

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -62,6 +62,90 @@ export function safeJSONParse(jsonString, fallback = null) {
   }
 }
 
+function readLocalStorageItem(key) {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return null;
+  }
+  return window.localStorage.getItem(key);
+}
+
+/**
+ * Reads and parses a localStorage value through the prototype-safe parser.
+ *
+ * @template T
+ * @param {string} key - localStorage key
+ * @param {T} [fallback=null] - Value returned when the key is missing or blocked
+ * @returns {T|unknown}
+ */
+export function getStoredValue(key, fallback = null) {
+  try {
+    const raw = readLocalStorageItem(key);
+    if (raw === null) {
+      return fallback;
+    }
+    return safeJSONParse(raw, fallback);
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Reads a string setting from localStorage.
+ *
+ * Legacy entries in this app sometimes store bare strings such as `dark` or
+ * `#f0d9b5`; those are returned as strings after the safe JSON parse fails.
+ *
+ * @param {string} key - localStorage key
+ * @param {string} fallback - Value returned on missing, invalid, or blocked reads
+ * @returns {string}
+ */
+export function getStoredString(key, fallback) {
+  try {
+    const raw = readLocalStorageItem(key);
+    if (raw === null) {
+      return fallback;
+    }
+    const parsed = safeJSONParse(raw, undefined);
+    if (typeof parsed === 'string') {
+      return parsed;
+    }
+    return parsed === undefined ? raw : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Reads a boolean setting from localStorage.
+ *
+ * @param {string} key - localStorage key
+ * @param {boolean} fallback - Value returned on missing, invalid, or blocked reads
+ * @returns {boolean}
+ */
+export function getStoredBoolean(key, fallback) {
+  const value = getStoredValue(key, fallback);
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+/**
+ * Reads a localStorage entry for backup export, preserving legacy bare strings.
+ *
+ * @param {string} key - localStorage key
+ * @returns {unknown|null}
+ */
+export function getStoredBackupValue(key) {
+  try {
+    const raw = readLocalStorageItem(key);
+    if (raw === null) {
+      return null;
+    }
+    const parsed = safeJSONParse(raw, undefined);
+    return parsed === undefined ? raw : parsed;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Strips unsafe filename characters and enforces a max length of 100.
  *


### PR DESCRIPTION
Fixes #78

## What changed
- Added small storage-read helpers around `safeJSONParse` for JSON values, legacy string settings, booleans, and backup export values.
- Routed the app-side `localStorage.getItem` reads in `src/` through those helpers.
- Added an ESLint guard so new direct `localStorage.getItem` calls get caught before they land.

I left the tiny pre-app `public/theme-init.js` bootstrap alone, since it runs before the app bundle can import the shared helper.

## Verification
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `rg -n localStorage\\.getItem src --glob *.{js,jsx,ts,tsx}` now only reports the approved helper in `src/utils/validation.js`