### PR TITLE
ci: harden CI security audit and refine release strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,10 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Run pnpm audit
         run: pnpm audit --audit-level=moderate

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,9 +9,9 @@
         "releaseRules": [
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
-          { "type": "perf", "release": "patch" },
-          { "type": "refactor", "release": "patch" },
-          { "type": "revert", "release": "patch" },
+          { "type": "perf", "release": false },
+          { "type": "refactor", "release": false },
+          { "type": "revert", "release": false },
           { "type": "docs", "release": false },
           { "type": "style", "release": false },
           { "type": "chore", "release": false },

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -62,6 +62,61 @@ if (!titlePattern.test(pr.title)) {
   fail('**PR title must not end with a period.**');
 }
 
+// Every commit subject (first line) must also be a valid Conventional Commit.
+// Merge commits are exempt — they are generated, not authored.
+const commits = danger.git.commits;
+const nonConventionalCommits = commits.filter((c) => {
+  const subject = c.message.split('\n', 1)[0];
+  if (/^Merge /.test(subject)) return false;
+  return !titlePattern.test(subject);
+});
+
+if (nonConventionalCommits.length > 0) {
+  fail(
+    [
+      '**One or more commits are not valid Conventional Commits:**',
+      '',
+      ...nonConventionalCommits.map(
+        (c) => `- \`${c.sha.slice(0, 7)}\` ${c.message.split('\n', 1)[0]}`
+      ),
+      '',
+      'Rewrite the offending commits (`git rebase -i`) before merge.'
+    ].join('\n')
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 1b. Sufficient commit context
+// ---------------------------------------------------------------------------
+const MIN_BODY_CHARS = 12;
+
+const contextlessCommits = commits.filter((c) => {
+  const subject = c.message.split('\n', 1)[0];
+  if (/^Merge /.test(subject)) return false;
+  return (
+    subject.replace(/^[a-z]+(\([\w$.\-*/ ]+\))?(!)?:\s*/, '').trim().length <
+    MIN_BODY_CHARS
+  );
+});
+
+if (commits.length === 0) {
+  warn(
+    '**This PR has no commits Danger can inspect.** Verify the branch is pushed.'
+  );
+} else if (contextlessCommits.length > 0) {
+  warn(
+    [
+      '**Some commits lack meaningful context** (subject too terse):',
+      '',
+      ...contextlessCommits.map(
+        (c) => `- \`${c.sha.slice(0, 7)}\` ${c.message.split('\n', 1)[0]}`
+      ),
+      '',
+      'Use a descriptive subject, and add a body explaining *why* for non-trivial changes.'
+    ].join('\n')
+  );
+}
+
 // ---------------------------------------------------------------------------
 // 2. Mandatory testing — source changes require test changes
 // ---------------------------------------------------------------------------
@@ -90,15 +145,15 @@ if (sourceChanges.length > 0 && testChanges.length === 0) {
 
 // fenParser is a hard invariant: any change requires its test to change too.
 const touchedFenParser = touched.some((f) =>
-  f.endsWith('src/utils/fenParser.ts')
+  f.endsWith('src/shared/utils/fenParser.ts')
 );
 const touchedFenParserTest = touched.some((f) =>
-  f.endsWith('src/utils/fenParser.test.js')
+  f.endsWith('src/shared/utils/fenParser.test.ts')
 );
 
 if (touchedFenParser && !touchedFenParserTest) {
   fail(
-    '**`fenParser.ts` changed without updating `fenParser.test.js`.** ' +
+    '**`fenParser.ts` changed without updating `fenParser.test.ts`.** ' +
       'Every change to the FEN parser requires a corresponding test (see CONTRIBUTING.md).'
   );
 }


### PR DESCRIPTION
## Summary

- Harden the `security-audit` CI job: install dependencies before `pnpm audit` so the job no longer hits the pnpm cache-path error that caused intermittent CI failures.
- Extend Danger PR governance: enforce Conventional Commits per-commit (not just the PR title) and warn on commits with insufficient context.
- Fix a latent Danger bug where the fenParser test invariant referenced the wrong paths (`src/utils/...` instead of `src/shared/utils/...`), so it never fired.
- Refine `semantic-release` so only `feat` (minor), `fix` (patch), and `BREAKING CHANGE` (major) trigger releases. `perf`/`refactor`/`revert` are demoted to non-releasing (they still appear in the changelog) to stop batches of refactors cutting tags.

## Rationale

The historical CI failures were a pnpm cache-path misconfiguration in the security-audit job, not an actual vulnerability (`pnpm audit` reported no known vulnerabilities). The "tag spam" was caused by `refactor`/`perf` triggering releases. A commit-count release gate was considered and rejected as an anti-pattern (a lone hotfix should not wait for other commits); type-based tuning achieves the goal of fewer, more meaningful tags.

## Test plan

- [ ] CI `security-audit` job passes (installs deps, runs `pnpm audit`).
- [ ] Danger runs on this PR and reports commit/title governance.
- [ ] Confirm a `refactor`-only merge to `master` does not cut a release.
- [ ] Confirm a `feat`/`fix` merge still cuts the expected version bump.