### PR TITLE
fix(auth): resolve sign-up failures, display name persistence, and DB schema gaps

### DIFF
--- a/src/features/auth/components/authErrors.ts
+++ b/src/features/auth/components/authErrors.ts
@@ -25,20 +25,34 @@ export function getAuthErrorMessage(error: unknown): string {
   if (normalized.includes('email not confirmed')) {
     return 'Please confirm your email before signing in.';
   }
-  if (normalized.includes('user already registered')) {
+  if (
+    normalized.includes('user already registered') ||
+    normalized.includes('already been registered')
+  ) {
     return 'An account with this email already exists.';
   }
   if (
     normalized.includes('rate limit') ||
-    normalized.includes('too many requests')
+    normalized.includes('too many requests') ||
+    normalized.includes('over_email_send_rate_limit') ||
+    normalized.includes('email rate limit exceeded')
   ) {
     return 'Too many attempts. Please wait a moment and try again.';
   }
   if (normalized.includes('password') && normalized.includes('least')) {
     return 'Your password does not meet the minimum requirements.';
   }
-  if (normalized.includes('unable to validate email')) {
+  if (
+    normalized.includes('unable to validate email') ||
+    normalized.includes('invalid email')
+  ) {
     return 'Please enter a valid email address.';
+  }
+  if (normalized.includes('signup is disabled')) {
+    return 'New registrations are currently disabled.';
+  }
+  if (normalized.includes('email link is invalid or has expired')) {
+    return 'This confirmation link has expired. Please sign up again.';
   }
 
   return 'Something went wrong. Please try again.';

--- a/src/features/auth/hooks/ProfileContext.tsx
+++ b/src/features/auth/hooks/ProfileContext.tsx
@@ -91,17 +91,25 @@ export function ProfileProvider({ children }: { children: React.ReactNode }) {
   }, [load, isAuthenticated, userId]);
 
   const setDisplayName = useCallback(
-    (name: string) => {
+    async (name: string): Promise<void> => {
       const trimmed = name.trim() || 'User';
-      setProfile((prev) => {
-        const next = { ...prev, displayName: trimmed };
-        if (isAuthenticated && userId) {
-          void profileService.updateDisplayName(userId, trimmed);
-        } else {
-          writeGuestProfile(next);
-        }
-        return next;
+      const prev = await new Promise<Profile>((resolve) => {
+        setProfile((p) => {
+          resolve(p);
+          return p;
+        });
       });
+      setProfile({ ...prev, displayName: trimmed });
+      if (isAuthenticated && userId) {
+        try {
+          await profileService.updateDisplayName(userId, trimmed);
+        } catch {
+          setProfile(prev);
+          throw new Error('Failed to save display name. Please try again.');
+        }
+      } else {
+        writeGuestProfile({ ...prev, displayName: trimmed });
+      }
     },
     [isAuthenticated, userId]
   );

--- a/src/features/auth/hooks/profileContextDef.ts
+++ b/src/features/auth/hooks/profileContextDef.ts
@@ -11,7 +11,7 @@ export interface ProfileContextValue {
   /** Display-only membership tier derived from `supporterMonthlyUsd`. */
   membershipTier: MembershipTier;
   loading: boolean;
-  setDisplayName: (name: string) => void;
+  setDisplayName: (name: string) => Promise<void>;
   /** months <= 0 clears supporter status. Defaults to a 1-month window. */
   setSupporter: (months?: number) => void;
   refresh: () => void;

--- a/src/features/auth/services/profileService.ts
+++ b/src/features/auth/services/profileService.ts
@@ -61,7 +61,7 @@ export function isActiveSupporter(supporterUntil: string | null): boolean {
 }
 
 export const profileService = {
-  /** Fetch a registered user's profile. Returns null on missing row/schema (UI falls back). */
+  /** Fetch a registered user's profile. Auto-creates the row if missing (trigger fallback). */
   get: async (userId: string): Promise<Profile | null> => {
     try {
       const { data, error } = await supabase
@@ -74,13 +74,25 @@ export const profileService = {
         if (isMissingSchemaError(error)) return null;
         throw error;
       }
-      if (!data) return null;
+
+      // Row missing means the on_auth_user_created trigger didn't run (schema not
+      // applied yet). Create it now so the rest of the app works normally.
+      if (!data) {
+        const { error: upsertError } = await supabase
+          .from('profiles')
+          .upsert(
+            { user_id: userId, display_name: 'User' },
+            { onConflict: 'user_id' }
+          );
+        if (upsertError && !isMissingSchemaError(upsertError)) {
+          logger.error('profileService.get — auto-create failed:', upsertError);
+        }
+        return DEFAULT_PROFILE;
+      }
 
       return {
         displayName: data.display_name ?? 'User',
         supporterUntil: data.supporter_until ?? null,
-        // No dollar column server-side today; amount-driven tier stays 0 for
-        // registered users until a real billing field exists.
         supporterMonthlyUsd: 0
       };
     } catch (error: unknown) {
@@ -89,16 +101,18 @@ export const profileService = {
     }
   },
 
-  /** Update the caller's display name (RLS: users can update own profile). */
+  /** Update the caller's display name. Upserts so a missing profile row is created on the fly. */
   updateDisplayName: async (userId: string, name: string): Promise<void> => {
-    try {
-      const { error } = await supabase
-        .from('profiles')
-        .update({ display_name: name })
-        .eq('user_id', userId);
-      if (error && !isMissingSchemaError(error)) throw error;
-    } catch (error: unknown) {
+    const { error } = await supabase
+      .from('profiles')
+      .upsert(
+        { user_id: userId, display_name: name },
+        { onConflict: 'user_id' }
+      )
+      .eq('user_id', userId);
+    if (error && !isMissingSchemaError(error)) {
       logger.error('profileService.updateDisplayName error:', error);
+      throw error;
     }
   },
 

--- a/src/pages/AuthPage/pages/SignUpPage.tsx
+++ b/src/pages/AuthPage/pages/SignUpPage.tsx
@@ -159,13 +159,24 @@ export function SignUpPage() {
 
     setIsSubmitting(true);
     try {
-      const { error: signUpError } = await supabase.auth.signUp({
+      const { data, error: signUpError } = await supabase.auth.signUp({
         email: email.trim(),
         password
       });
 
       if (signUpError) {
         setEmailError(getAuthErrorMessage(signUpError));
+        return;
+      }
+
+      // Supabase returns identities: [] when email confirmation is disabled AND
+      // the email is already registered — no error is thrown, so we detect it here.
+      if (
+        data.user &&
+        Array.isArray(data.user.identities) &&
+        data.user.identities.length === 0
+      ) {
+        setEmailError('An account with this email already exists.');
         return;
       }
 

--- a/src/pages/SettingsPage/sections/account/IdentityHeader.tsx
+++ b/src/pages/SettingsPage/sections/account/IdentityHeader.tsx
@@ -17,28 +17,48 @@ export function IdentityHeader({
   displayName: string;
   email: string | null;
   loading: boolean;
-  onSaveName: (name: string) => void;
+  onSaveName: (name: string) => Promise<void>;
   isAuthenticated: boolean;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(displayName);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Reset the draft whenever editing opens or the upstream name resolves.
   useEffect(() => {
     if (editing) {
       setDraft(displayName);
+      setSaveError(null);
       inputRef.current?.focus();
     }
   }, [editing, displayName]);
 
   const trimmed = sanitizeInput(draft).slice(0, MAX_DISPLAY_NAME).trim();
   const canSave = trimmed.length > 0 && trimmed !== displayName;
-  const commit = () => {
-    if (canSave) onSaveName(trimmed);
-    setEditing(false);
+  const commit = async () => {
+    if (!canSave) {
+      setEditing(false);
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await onSaveName(trimmed);
+      setEditing(false);
+    } catch (err: unknown) {
+      setSaveError(
+        err instanceof Error ? err.message : 'Failed to save. Please try again.'
+      );
+    } finally {
+      setSaving(false);
+    }
   };
-  const cancel = () => setEditing(false);
+  const cancel = () => {
+    setEditing(false);
+    setSaveError(null);
+  };
 
   return (
     <section className="flex items-center gap-4 rounded-2xl border border-border bg-surface-elevated p-5">
@@ -51,45 +71,49 @@ export function IdentityHeader({
       </div>
       <div className="min-w-0 flex-1">
         {editing ? (
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <label htmlFor="account-display-name" className="sr-only">
-              Display name
-            </label>
-            <input
-              ref={inputRef}
-              id="account-display-name"
-              type="text"
-              value={draft}
-              maxLength={MAX_DISPLAY_NAME}
-              disabled={loading}
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') commit();
-                if (e.key === 'Escape') cancel();
-              }}
-              placeholder="Your name"
-              className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors duration-200 disabled:opacity-60"
-            />
-            <div className="flex shrink-0 gap-2">
-              <button
-                type="button"
-                onClick={commit}
-                disabled={!canSave}
-                aria-label="Save display name"
-                className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-sm font-semibold text-bg transition-colors hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <Check className="h-4 w-4" aria-hidden="true" />
-                Save
-              </button>
-              <button
-                type="button"
-                onClick={cancel}
-                aria-label="Cancel editing display name"
-                className="inline-flex items-center justify-center rounded-lg border border-border bg-surface px-3 py-2 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-              >
-                <X className="h-4 w-4" aria-hidden="true" />
-              </button>
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <label htmlFor="account-display-name" className="sr-only">
+                Display name
+              </label>
+              <input
+                ref={inputRef}
+                id="account-display-name"
+                type="text"
+                value={draft}
+                maxLength={MAX_DISPLAY_NAME}
+                disabled={loading || saving}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void commit();
+                  if (e.key === 'Escape') cancel();
+                }}
+                placeholder="Your name"
+                className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors duration-200 disabled:opacity-60"
+              />
+              <div className="flex shrink-0 gap-2">
+                <button
+                  type="button"
+                  onClick={() => void commit()}
+                  disabled={!canSave || saving}
+                  aria-label="Save display name"
+                  className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-accent px-3 py-2 text-sm font-semibold text-bg transition-colors hover:bg-accent-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <Check className="h-4 w-4" aria-hidden="true" />
+                  {saving ? 'Saving…' : 'Save'}
+                </button>
+                <button
+                  type="button"
+                  onClick={cancel}
+                  disabled={saving}
+                  aria-label="Cancel editing display name"
+                  className="inline-flex items-center justify-center rounded-lg border border-border bg-surface px-3 py-2 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:opacity-50"
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              </div>
             </div>
+            {saveError && <p className="text-xs text-error">{saveError}</p>}
           </div>
         ) : (
           <>

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -868,7 +868,7 @@ BEGIN
     -- display_name defaults to 'User' for every new signup (the app's unified
     -- profile model lets the user rename it later). email still stored as-is.
     INSERT INTO public.profiles (user_id, email, display_name)
-    VALUES (new.id, new.email, 'User')  -- new.email may be NULL — allowed.
+    VALUES (new.id, NULLIF(new.email, ''), 'User')  -- new.email may be NULL — allowed.
     ON CONFLICT (user_id) DO NOTHING;
 
     INSERT INTO public.user_security (user_id)
@@ -1054,9 +1054,23 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = auth, public;
 
--- ... (around line 1010)
 REVOKE EXECUTE ON FUNCTION public.delete_own_account()                          FROM PUBLIC, anon, authenticated;
 GRANT  EXECUTE ON FUNCTION public.delete_own_account()                          TO authenticated;
 
--- ... (rest of grants)
 GRANT  EXECUTE ON FUNCTION public.set_supporter_status(INT)                        TO authenticated;
+
+-- ===========================================================================
+-- BACKFILL: provision profile + security rows for any auth.users rows that
+-- were created before the on_auth_user_created trigger was installed (i.e.
+-- when schema had not yet been applied to the project).
+-- Safe to re-run: ON CONFLICT DO NOTHING makes it idempotent.
+-- Run once after applying this schema to an existing project.
+-- ===========================================================================
+INSERT INTO public.profiles (user_id, email, display_name)
+SELECT id, NULLIF(email, ''), 'User'
+FROM auth.users
+ON CONFLICT (user_id) DO NOTHING;
+
+INSERT INTO public.user_security (user_id)
+SELECT id FROM auth.users
+ON CONFLICT (user_id) DO NOTHING;


### PR DESCRIPTION
## What & why

Fixes three interconnected auth bugs reported in production:

1. **Sign-up silently accepts already-registered emails** — Supabase v2 returns `identities: []` instead of an error when email confirmation is off and the email already exists. The client now detects this and shows a clear message.

2. **Display name resets to "User" after save** — `updateDisplayName` was calling `.update()` which silently no-ops when the profile row is missing (trigger not applied). Switched to `.upsert()` so the row is created on the fly. Also made `setDisplayName` async with proper rollback and error surfacing to the UI.

3. **Profile row missing on first login** — If the `on_auth_user_created` trigger was not installed, `profileService.get()` returned null and the app fell back to defaults on every load. It now auto-upserts a fallback row so login works regardless of trigger state.

Additional: expanded `authErrors` to map Supabase v2 error strings for email rate limit, signup disabled, and expired confirmation links.

The DB commit adds idempotent backfill `INSERT ... ON CONFLICT DO NOTHING` statements for any `auth.users` rows created before the trigger was installed.

## Type

fix

## Checklist

- [x] `pnpm validate` passes (types, lint, format, test)
- [x] No `any` / `@ts-ignore` / non-null `!`, no hardcoded hex in JSX
- [x] Screenshots attached for UI changes — N/A (error states only, no visual layout changes)