### PR TITLE
fix(export): frame rendering, coordinate placement, and pagination overflow

### DIFF
--- a/src/components/features/ColorPicker/BoardThemePicker.tsx
+++ b/src/components/features/ColorPicker/BoardThemePicker.tsx
@@ -8,8 +8,6 @@ import {
 } from 'react';
 
 import {
-  ChevronLeft,
-  ChevronRight,
   Palette,
   Pencil,
   Plus,
@@ -20,6 +18,8 @@ import {
 
 import { useNotifications, useThemePresets } from '@hooks';
 import { BOARD_THEMES } from '@constants';
+
+import { Pagination } from '@shared/ui';
 
 import { ColorPickerPanel } from './parts/ColorPickerPanel';
 import { Swatch } from './parts/Swatch';
@@ -356,43 +356,13 @@ const BoardThemePicker = memo(function BoardThemePicker({
       )}
 
       {tab === 'main' && totalPages > 1 && (
-        <div className="mt-auto flex items-center justify-center gap-3 pt-1">
-          <button
-            type="button"
-            onClick={() =>
-              setCurrentPage((currentPage - 1 + totalPages) % totalPages)
-            }
-            aria-label="Previous page"
-            className="hidden rounded-md border border-border bg-surface p-1.5 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent sm:inline-flex"
-          >
-            <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-          </button>
-
-          <div className="flex items-center gap-2">
-            {Array.from({ length: totalPages }, (_, i) => (
-              <button
-                key={i}
-                type="button"
-                onClick={() => setCurrentPage(i)}
-                aria-label={`Page ${i + 1}`}
-                aria-current={currentPage === i ? 'page' : undefined}
-                className={`h-2 rounded-full transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                  currentPage === i
-                    ? 'w-5 bg-accent'
-                    : 'w-2 bg-border hover:bg-text-muted'
-                }`}
-              />
-            ))}
-          </div>
-
-          <button
-            type="button"
-            onClick={() => setCurrentPage((currentPage + 1) % totalPages)}
-            aria-label="Next page"
-            className="hidden rounded-md border border-border bg-surface p-1.5 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent sm:inline-flex"
-          >
-            <ChevronRight className="h-4 w-4" aria-hidden="true" />
-          </button>
+        <div className="mt-auto pt-1">
+          <Pagination
+            page={currentPage}
+            pageCount={totalPages}
+            onChange={setCurrentPage}
+            label="Board theme pages"
+          />
         </div>
       )}
     </div>

--- a/src/components/features/ColorPicker/PieceGridShared.tsx
+++ b/src/components/features/ColorPicker/PieceGridShared.tsx
@@ -1,9 +1,9 @@
 import { memo, useCallback, useEffect, useState } from 'react';
 
-import { ChevronLeft, ChevronRight } from 'lucide-react';
-
 import { usePagedCarousel } from '@hooks';
 import type { PieceSet } from '@app-types';
+
+import { Pagination } from '@shared/ui';
 
 /** Default rows shown per page; columns come from the responsive breakpoint. */
 const DEFAULT_PIECE_ROWS = 2;
@@ -142,44 +142,12 @@ function PieceGridSharedComponent({
       </div>
 
       {showPager && (
-        <div className="flex items-center justify-center gap-3">
-          {/* Arrow buttons — primarily for desktop/pointer; hidden from AT since
-              the dots already expose page state. Swipe covers touch. */}
-          <button
-            type="button"
-            onClick={prev}
-            aria-label="Previous page"
-            className="hidden rounded-md border border-border bg-surface p-1.5 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent sm:inline-flex"
-          >
-            <ChevronLeft className="h-4 w-4" aria-hidden="true" />
-          </button>
-
-          <div className="flex items-center gap-2">
-            {Array.from({ length: pageCount }, (_, i) => (
-              <button
-                key={i}
-                type="button"
-                onClick={() => goTo(i)}
-                aria-label={`Page ${i + 1} of ${pageCount}`}
-                aria-current={page === i ? 'page' : undefined}
-                className={`h-2 rounded-full transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                  page === i
-                    ? 'w-5 bg-accent'
-                    : 'w-2 bg-border hover:bg-text-muted'
-                }`}
-              />
-            ))}
-          </div>
-
-          <button
-            type="button"
-            onClick={next}
-            aria-label="Next page"
-            className="hidden rounded-md border border-border bg-surface p-1.5 text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent sm:inline-flex"
-          >
-            <ChevronRight className="h-4 w-4" aria-hidden="true" />
-          </button>
-        </div>
+        <Pagination
+          page={page}
+          pageCount={pageCount}
+          onChange={goTo}
+          label="Piece set pages"
+        />
       )}
     </div>
   );

--- a/src/shared/ui/Pagination/Pagination.test.ts
+++ b/src/shared/ui/Pagination/Pagination.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getSlots, MAX_VISIBLE_DOTS, type Slot } from './getSlots.ts';
+
+const dots = (slots: Slot[]) =>
+  slots.filter((s): s is Extract<Slot, { kind: 'dot' }> => s.kind === 'dot');
+const ellipses = (slots: Slot[]) => slots.filter((s) => s.kind === 'ellipsis');
+const activePage = (slots: Slot[]) =>
+  dots(slots).find((d) => d.tone === 'active')?.page;
+
+test('renders one dot per page when the count fits the window', () => {
+  const slots = getSlots(2, MAX_VISIBLE_DOTS);
+  assert.equal(dots(slots).length, MAX_VISIBLE_DOTS);
+  assert.equal(ellipses(slots).length, 0);
+  assert.deepEqual(
+    dots(slots).map((d) => d.page),
+    [0, 1, 2, 3, 4, 5, 6]
+  );
+});
+
+test('marks exactly the active page', () => {
+  const slots = getSlots(3, 5);
+  assert.equal(dots(slots).filter((d) => d.tone === 'active').length, 1);
+  assert.equal(activePage(slots), 3);
+});
+
+test('never renders more than MAX_VISIBLE_DOTS dots once it overflows', () => {
+  for (let page = 0; page < 50; page++) {
+    const slots = getSlots(page, 50);
+    assert.ok(
+      dots(slots).length <= MAX_VISIBLE_DOTS,
+      `page ${page} rendered ${dots(slots).length} dots`
+    );
+  }
+});
+
+test('keeps the active page inside the visible window for every page', () => {
+  for (let page = 0; page < 50; page++) {
+    const slots = getSlots(page, 50);
+    assert.equal(activePage(slots), page, `active lost at page ${page}`);
+  }
+});
+
+test('shows only a trailing ellipsis on the first page', () => {
+  const slots = getSlots(0, 20);
+  const e = ellipses(slots);
+  assert.equal(e.length, 1);
+  assert.equal(e[0]?.side, 'end');
+  assert.equal(dots(slots)[0]?.page, 0);
+});
+
+test('shows only a leading ellipsis on the last page', () => {
+  const last = 19;
+  const slots = getSlots(last, 20);
+  const e = ellipses(slots);
+  assert.equal(e.length, 1);
+  assert.equal(e[0]?.side, 'start');
+  assert.equal(dots(slots).at(-1)?.page, last);
+});
+
+test('shows ellipses on both sides in the middle', () => {
+  const slots = getSlots(10, 20);
+  const sides = ellipses(slots).map((e) => e.side);
+  assert.deepEqual(sides, ['start', 'end']);
+});
+
+test('fades the window edges but not the active dot when overflowing', () => {
+  const slots = getSlots(10, 20);
+  const d = dots(slots);
+  assert.equal(d[0]?.tone, 'faded');
+  assert.equal(d.at(-1)?.tone, 'faded');
+  assert.equal(activePage(slots), 10);
+});
+
+test('handles a single page without an active marker context error', () => {
+  const slots = getSlots(0, 1);
+  assert.equal(dots(slots).length, 1);
+  assert.equal(slots[0]?.kind === 'dot' && slots[0].tone, 'active');
+});

--- a/src/shared/ui/Pagination/Pagination.tsx
+++ b/src/shared/ui/Pagination/Pagination.tsx
@@ -1,0 +1,101 @@
+import { memo } from 'react';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+import { getSlots } from './getSlots';
+
+const DOT_TONE: Record<'active' | 'normal' | 'faded', string> = {
+  active: 'h-2 w-5 bg-accent',
+  normal: 'h-2 w-2 bg-border hover:bg-text-muted',
+  faded: 'h-1.5 w-1.5 bg-border/60 hover:bg-border'
+};
+
+const ARROW_CLASS =
+  'hidden shrink-0 rounded-md border border-border bg-surface p-1.5 ' +
+  'text-text-secondary transition-colors hover:bg-surface-hover ' +
+  'hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 ' +
+  'focus-visible:ring-accent sm:inline-flex';
+
+export interface PaginationProps {
+  /** Active page index (0-based). */
+  page: number;
+  /** Total number of pages. The component renders nothing when this is ≤ 1. */
+  pageCount: number;
+  /** Called with the next page index. Edge steps wrap around. */
+  onChange: (page: number) => void;
+  /** Accessible label for the surrounding nav landmark. */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Compact, accessible page indicator: prev/next arrows (pointer + `sm` screens)
+ * flanking a centred row of dots. The active dot widens into an accent pill; the
+ * rest stay small. A sliding window caps the row at {@link MAX_VISIBLE_DOTS}
+ * dots so even long lists never overflow narrow phone/tablet columns — the bug
+ * the old per-call pagers hit was an unbounded dot row, not the pill itself.
+ *
+ * Stepping past either edge wraps, matching the swipe-to-page behaviour used by
+ * the touch carousels that consume this component.
+ */
+const Pagination = memo(function Pagination({
+  page,
+  pageCount,
+  onChange,
+  label = 'Pagination',
+  className = ''
+}: PaginationProps) {
+  if (pageCount <= 1) return null;
+
+  const goPrev = () => onChange((page - 1 + pageCount) % pageCount);
+  const goNext = () => onChange((page + 1) % pageCount);
+
+  return (
+    <nav
+      aria-label={label}
+      className={`flex items-center justify-center gap-3 ${className}`}
+    >
+      <button
+        type="button"
+        onClick={goPrev}
+        aria-label="Previous page"
+        className={ARROW_CLASS}
+      >
+        <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+      </button>
+
+      <div className="flex items-center gap-1.5">
+        {getSlots(page, pageCount).map((slot) =>
+          slot.kind === 'ellipsis' ? (
+            <span
+              key={`ellipsis-${slot.side}`}
+              aria-hidden="true"
+              className="h-1.5 w-1.5 rounded-full bg-border opacity-40"
+            />
+          ) : (
+            <button
+              key={slot.page}
+              type="button"
+              onClick={() => onChange(slot.page)}
+              aria-label={`Page ${slot.page + 1} of ${pageCount}`}
+              aria-current={slot.page === page ? 'page' : undefined}
+              className={`rounded-full transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent ${DOT_TONE[slot.tone]}`}
+            />
+          )
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={goNext}
+        aria-label="Next page"
+        className={ARROW_CLASS}
+      >
+        <ChevronRight className="h-4 w-4" aria-hidden="true" />
+      </button>
+    </nav>
+  );
+});
+
+Pagination.displayName = 'Pagination';
+export default Pagination;

--- a/src/shared/ui/Pagination/getSlots.ts
+++ b/src/shared/ui/Pagination/getSlots.ts
@@ -1,0 +1,45 @@
+/** Largest number of dots drawn before a sliding window kicks in. Odd so the
+ *  active dot can sit dead-centre with equal context on each side. */
+export const MAX_VISIBLE_DOTS = 7;
+
+/** One rendered slot in the dot row: a real page dot or a trimmed-edge marker. */
+export type Slot =
+  | { kind: 'dot'; page: number; tone: 'active' | 'normal' | 'faded' }
+  | { kind: 'ellipsis'; side: 'start' | 'end' };
+
+/**
+ * Computes the visible dot slots for the current page.
+ *
+ * When every page fits, all dots render at full size. Once the count exceeds
+ * {@link MAX_VISIBLE_DOTS}, a window slides to keep the active page centred and
+ * an ellipsis marker stands in for the hidden pages on each trimmed edge.
+ */
+export function getSlots(page: number, pageCount: number): Slot[] {
+  if (pageCount <= MAX_VISIBLE_DOTS) {
+    return Array.from({ length: pageCount }, (_, i) => ({
+      kind: 'dot',
+      page: i,
+      tone: i === page ? 'active' : 'normal'
+    }));
+  }
+
+  const half = Math.floor(MAX_VISIBLE_DOTS / 2);
+  let start = Math.max(0, page - half);
+  const end = Math.min(pageCount - 1, start + MAX_VISIBLE_DOTS - 1);
+  start = Math.max(0, end - MAX_VISIBLE_DOTS + 1);
+
+  const slots: Slot[] = [];
+  if (start > 0) slots.push({ kind: 'ellipsis', side: 'start' });
+
+  for (let i = start; i <= end; i++) {
+    const atEdge = i === start || i === end;
+    slots.push({
+      kind: 'dot',
+      page: i,
+      tone: i === page ? 'active' : atEdge ? 'faded' : 'normal'
+    });
+  }
+
+  if (end < pageCount - 1) slots.push({ kind: 'ellipsis', side: 'end' });
+  return slots;
+}

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -6,5 +6,7 @@ export type { ModalType } from './Modal/Modal';
 export { default as Modal } from './Modal/Modal';
 export { default as ModalShell } from './Modal/ModalShell';
 export { default as NotificationContainer } from './NotificationContainer/NotificationContainer';
+export type { PaginationProps } from './Pagination/Pagination';
+export { default as Pagination } from './Pagination/Pagination';
 export { Seo } from './Seo/Seo';
 export { default as Switch } from './Switch/Switch';

--- a/src/shared/utils/canvasRenderer.ts
+++ b/src/shared/utils/canvasRenderer.ts
@@ -176,20 +176,12 @@ export async function createUltraQualityCanvas(
 
   if (shouldShowFrame) {
     ctx.fillStyle = '#333333';
-    ctx.fillRect(frameOffset, 0, borderSize + finalBoardPixels, frameThickness);
-    ctx.fillRect(
-      frameOffset,
-      frameOffset + finalBoardPixels + borderSize,
-      borderSize + finalBoardPixels,
-      frameThickness
-    );
+    // Top and bottom bars span the full canvas width (corners included)
+    ctx.fillRect(0, 0, canvasWidth, frameThickness);
+    ctx.fillRect(0, canvasHeight - frameThickness, canvasWidth, frameThickness);
+    // Left and right bars span the full canvas height
     ctx.fillRect(0, 0, frameThickness, canvasHeight);
-    ctx.fillRect(
-      frameOffset + borderSize + finalBoardPixels,
-      0,
-      frameThickness,
-      canvasHeight
-    );
+    ctx.fillRect(canvasWidth - frameThickness, 0, frameThickness, canvasHeight);
   }
 
   if (effectiveCoordBorder && (format === 'jpeg' || format === 'jpg')) {
@@ -279,7 +271,8 @@ export async function createUltraQualityCanvas(
       finalBoardPixels,
       true,
       false,
-      boardY
+      boardY,
+      frameOffset
     );
   }
 

--- a/src/shared/utils/coordinateCalculations.ts
+++ b/src/shared/utils/coordinateCalculations.ts
@@ -157,12 +157,13 @@ function getBaselineFromCenter(
  *
  * @param ctx - Canvas context
  * @param squareSize - Pixel size of one square
- * @param borderSize - Width of the coordinate border area
+ * @param borderSize - Width of the coordinate border area (may include frame offset)
  * @param flipped - Whether the board is flipped
  * @param boardSize - Total board pixel size (excluding border)
  * @param forExport - Use black text for export output
  * @param displayWhite - Use white text for dark backgrounds
  * @param boardStartY - Override Y offset of the board origin
+ * @param frameOffset - Frame thickness offset (subtracted from borderSize to get pure coord border)
  */
 export function drawCoordinates(
   ctx: CanvasRenderingContext2D,
@@ -172,11 +173,14 @@ export function drawCoordinates(
   boardSize: number,
   forExport: boolean = false,
   displayWhite: boolean = true,
-  boardStartY?: number
+  boardStartY?: number,
+  frameOffset: number = 0
 ): void {
   const coordParams = getCoordinateParams(boardSize);
   const { fontSize, fontWeight } = coordParams;
   const effectiveBorder = borderSize ?? coordParams.borderSize;
+  // coordBorder is the pure coordinate band width without any frame offset
+  const coordBorder = effectiveBorder - frameOffset;
 
   const boardY = boardStartY ?? (forExport ? 0 : effectiveBorder);
 
@@ -196,7 +200,8 @@ export function drawCoordinates(
     const squareBottom = boardY + (row + 1) * squareSize;
     const centerY = Math.round((squareTop + squareBottom) / 2);
     const yPos = getBaselineFromCenter(centerY, rankMetrics);
-    const xPos = Math.round(effectiveBorder * 0.5);
+    // Center within the coord border band only (exclude frame offset)
+    const xPos = Math.round(frameOffset + coordBorder * 0.5);
     ctx.fillText(rank.toString(), xPos, yPos);
   }
 
@@ -204,9 +209,8 @@ export function drawCoordinates(
     const fileIndex = flipped ? 7 - col : col;
     const file = String.fromCharCode(97 + fileIndex);
     const xPos = getCellCenter(effectiveBorder, squareSize, col);
-    const bottomCenter = Math.round(
-      boardY + boardSize + effectiveBorder * 0.55
-    );
+    // Center within the coord border band below the board (exclude frame offset)
+    const bottomCenter = Math.round(boardY + boardSize + coordBorder * 0.55);
     const yPos = getBaselineFromCenter(bottomCenter, fileMetrics);
     ctx.fillText(file, xPos, yPos);
   }

--- a/src/shared/utils/imageOptimizer.ts
+++ b/src/shared/utils/imageOptimizer.ts
@@ -183,8 +183,7 @@ export function calculateRenderSurfaceSize(
     exportQuality
   );
   const borderSize = showCoords ? exportSize.borderSize : 0;
-  const shouldShowFrame =
-    !!showThinFrame && getExportMode(exportSize.exportQuality) === 'print';
+  const shouldShowFrame = !!showThinFrame;
   const frameThickness = shouldShowFrame
     ? Math.max(2, Math.round(exportSize.boardPixels * 0.003))
     : 0;

--- a/src/shared/utils/svgExporter.ts
+++ b/src/shared/utils/svgExporter.ts
@@ -1,7 +1,7 @@
 import { ChessBoard, isChessBoard } from '@app-types';
 
 import { parseFEN } from './fenParser';
-import { getExportMode, shouldForceCoordinateBorder } from './imageOptimizer';
+import { shouldForceCoordinateBorder } from './imageOptimizer';
 import {
   getPieceKey,
   imageToEmbeddableDataURL,
@@ -71,7 +71,7 @@ export async function generateBoardSVG(
   const withBorder =
     withCoords &&
     (showCoordinateBorder || shouldForceCoordinateBorder(exportQuality));
-  const withFrame = !!showThinFrame && getExportMode(exportQuality) === 'print';
+  const withFrame = !!showThinFrame;
   const framePx = withFrame ? Math.max(2, Math.round(boardPx * 0.003)) * 2 : 0;
 
   const totalWidth = borderPx + boardPx + framePx;
@@ -198,14 +198,15 @@ export async function generateBoardSVG(
 
     for (let col = 0; col < 8; col++) {
       const x = boardX + col * squarePx + squarePx / 2;
-      const y = boardY + boardPx + borderPx * 0.7;
+      const y = boardY + boardPx + borderPx * 0.55 + fontSize * 0.35;
       parts.push(
         `<text x="${x}" y="${y}" ${textAttrs}>${sanitizeInput(files[col])}</text>`
       );
     }
 
     for (let row = 0; row < 8; row++) {
-      const x = boardX - borderPx * 0.5;
+      const frameOffset = withFrame ? framePx / 2 : 0;
+      const x = frameOffset + borderPx * 0.5;
       const y = boardY + row * squarePx + squarePx / 2 + fontSize * 0.35;
       parts.push(
         `<text x="${x}" y="${y}" ${textAttrs}>${sanitizeInput(ranks[row])}</text>`


### PR DESCRIPTION
## What & why

Fixes three independent bugs discovered on the export and board-style pages.

**Export frame** — `showThinFrame` was silently ignored for 3× and 4× quality presets because `shouldShowFrame` checked `getExportMode() === 'print'`. Removed the quality gate so the toggle works at all quality levels. Canvas frame corners had gaps (four partial `fillRect` calls); replaced with two full-width bars and two full-height bars using `canvasWidth`/`canvasHeight`. SVG exporter had the same quality gate and a mismatched file-label Y multiplier (0.7 vs canvas 0.55); both corrected.

**Coordinate placement with frame active** — when a frame was drawn, rank labels landed inside the frame band instead of the coordinate border area. `drawCoordinates` now accepts `frameOffset`; `xPos` and `bottomCenter` are computed against `coordBorder = effectiveBorder − frameOffset`.

**Pagination overflow on mobile/tablet** — the theme picker and piece-set grid each had a copy of the same inline pager. With an unbounded dot row, the active `w-5` pill plus multiple dots overflowed narrow viewports. Extracted a shared `Pagination` component (`shared/ui`) with a 7-dot sliding window so the row is always bounded. Active pill (`w-5`) is preserved. Duplicate markup (~50 lines × 2) removed.

## Type

fix · feat

## Checklist

- [x] `pnpm validate` passes (types, lint, format, test)
- [x] No `any` / `@ts-ignore` / non-null `!`, no hardcoded hex in JSX
- [x] Screenshots attached for UI changes

**Before** — active dot: 19 px pill, no overflow cap, frame toggle broken on 3×/4×  
**After** — same pill, 7-dot window (overflow impossible), frame works at all qualities

Verified with Puppeteer across 375 / 414 / 768 / 1024 px viewports: `maxW` 19–21 px (pill), `overflow: false` everywhere.