### PR TITLE
feat(seo): add structured data, page headings, and richer metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
     <link rel="dns-prefetch" href="https://lichess1.org" />
     <link rel="preconnect" href="https://lichess1.org" crossorigin />
 
-    <title>ChessVision</title>
+    <title>ChessVision — Free Chess Diagram Generator</title>
   </head>
   <body class="preload">
     <script src="/theme-init.js"></script>

--- a/src/pages/AboutPage/AboutPage.tsx
+++ b/src/pages/AboutPage/AboutPage.tsx
@@ -107,6 +107,7 @@ const AboutPage = memo(function AboutPage() {
         {...getRouteSeo('/about')}
         schema={[WEBSITE_SCHEMA, ORGANIZATION_SCHEMA]}
       />
+      <h1 className="sr-only">About ChessVision</h1>
       {/* Two-column shell, constrained to the navbar's width so the page reads
           as one column under the bar: a sticky left category rail (always
           visible, never collapses) and a scrolling content column on the right

--- a/src/pages/AdvancedFENInputPage/AdvancedFENInputPage.tsx
+++ b/src/pages/AdvancedFENInputPage/AdvancedFENInputPage.tsx
@@ -5,6 +5,7 @@ import { Eye, Globe, List, Sliders } from 'lucide-react';
 import { ExportProgress } from '@/components/features';
 import { type PageTabGroup, PageTabs } from '@/components/layout';
 import {
+  ADVANCED_FEN_BREADCRUMB_SCHEMA,
   ADVANCED_FEN_CONFIG,
   getRouteSeo,
   SOFTWARE_APP_SCHEMA
@@ -76,7 +77,11 @@ const AdvancedFENInputPage = memo(function AdvancedFENInputPage(
       data-page-scroll
       className="bg-bg min-h-full lg:h-screen lg:max-h-screen lg:overflow-hidden animate-pageEnter"
     >
-      <Seo {...getRouteSeo('/advanced-fen')} schema={SOFTWARE_APP_SCHEMA} />
+      <Seo
+        {...getRouteSeo('/advanced-fen')}
+        schema={[SOFTWARE_APP_SCHEMA, ADVANCED_FEN_BREADCRUMB_SCHEMA]}
+      />
+      <h1 className="sr-only">Batch FEN Export — Chess Diagram Studio</h1>
 
       <div className="page-container flex flex-col gap-6 py-6 sm:py-8 md:flex-row md:gap-8 lg:gap-10 lg:h-full lg:overflow-hidden">
         {/* Sidebar: sticky left column on md+ */}

--- a/src/pages/ExportPage/ExportPage.tsx
+++ b/src/pages/ExportPage/ExportPage.tsx
@@ -8,6 +8,11 @@ import { type PageTabGroup, PageTabs } from '@/components/layout';
 import { useHomeExport, useNotifications, usePieceImages } from '@hooks';
 
 import { safeJSONParse } from '@utils';
+import {
+  EXPORT_BREADCRUMB_SCHEMA,
+  EXPORT_HOWTO_SCHEMA,
+  getRouteSeo
+} from '@constants';
 import { Seo } from '@shared/ui';
 import BoardStyleStep from './components/BoardStyleStep';
 import ExportSettingsStep from './components/ExportSettingsStep';
@@ -68,9 +73,8 @@ const ExportPage = () => {
     return (
       <>
         <Seo
-          name="Export Chess Diagram"
-          path="/export"
-          description="Export your chess diagram as a high-resolution PNG, JPEG, or SVG. Choose DPI, board size, piece style, and colors — then download instantly. Free, no watermarks."
+          {...getRouteSeo('/export')}
+          schema={[EXPORT_HOWTO_SCHEMA, EXPORT_BREADCRUMB_SCHEMA]}
         />
         <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6 text-center px-4">
           <div className="flex flex-col items-center gap-3">
@@ -78,9 +82,10 @@ const ExportPage = () => {
               className="w-12 h-12 text-text-secondary/40"
               strokeWidth={1.5}
             />
-            <h1 className="text-xl font-semibold text-text-primary">
+            <h1 className="sr-only">Export Chess Diagram</h1>
+            <p className="text-xl font-semibold text-text-primary">
               No board loaded
-            </h1>
+            </p>
             <p className="text-text-secondary text-sm max-w-xs">
               Open a position from the editor to export it as a high-resolution
               image.
@@ -101,9 +106,8 @@ const ExportPage = () => {
   return (
     <>
       <Seo
-        name="Export Chess Diagram"
-        path="/export"
-        description="Export your chess diagram as a high-resolution PNG, JPEG, or SVG. Choose DPI, board size, piece style, and colors — then download instantly. Free, no watermarks."
+        {...getRouteSeo('/export')}
+        schema={[EXPORT_HOWTO_SCHEMA, EXPORT_BREADCRUMB_SCHEMA]}
       />
       <ExportPageInner config={initialState} />
     </>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -96,6 +96,9 @@ const HomePage: React.FC = () => {
         image={dynamicOgImage ?? getRouteSeo('/').image}
         schema={[WEBSITE_SCHEMA, SOFTWARE_APP_SCHEMA, HOME_FAQ_SCHEMA]}
       />
+      <h1 className="sr-only">
+        Free Chess Diagram Generator — FEN to PNG, JPEG &amp; SVG
+      </h1>
       <div className="w-full bg-bg py-2 overflow-x-hidden min-h-full lg:h-full lg:overflow-hidden flex flex-col lg:justify-center animate-pageEnter">
         <div className="flex flex-col gap-fluid-xs lg:gap-3 page-container pt-1.5 lg:pt-0">
           <div className="min-w-0">

--- a/src/shared/constants/seoConstants.ts
+++ b/src/shared/constants/seoConstants.ts
@@ -123,13 +123,6 @@ export const SOFTWARE_APP_SCHEMA = {
     priceCurrency: 'USD',
     availability: 'https://schema.org/InStock'
   },
-  aggregateRating: {
-    '@type': 'AggregateRating',
-    ratingValue: '5',
-    ratingCount: '1',
-    bestRating: '5',
-    worstRating: '1'
-  },
   publisher: { '@id': `${SITE_URL}/#organization` }
 };
 
@@ -180,6 +173,86 @@ export const HOME_FAQ_SCHEMA = {
         '@type': 'Answer',
         text: 'Yes, ChessVision is forever free and open-source. All features — including high-resolution export, batch processing, and cloud sync — are free with no paywalls. Visit chessvision.org to get started.'
       }
+    }
+  ]
+};
+
+/**
+ * HowTo schema for the Export page — targets "how to export chess diagram" rich results.
+ */
+export const EXPORT_HOWTO_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'HowTo',
+  '@id': `${SITE_URL}/export#howto`,
+  name: 'How to Export a Chess Diagram',
+  description:
+    'Convert a FEN position to a high-resolution PNG, JPEG, or SVG chess diagram using ChessVision.',
+  step: [
+    {
+      '@type': 'HowToStep',
+      name: 'Enter FEN',
+      text: 'Paste your FEN string into the board editor on chessvision.org.'
+    },
+    {
+      '@type': 'HowToStep',
+      name: 'Customize',
+      text: 'Choose your board theme, piece set, coordinates, and physical board size.'
+    },
+    {
+      '@type': 'HowToStep',
+      name: 'Select format',
+      text: 'Pick PNG, JPEG, or SVG and set the quality preset (300–1200 DPI).'
+    },
+    {
+      '@type': 'HowToStep',
+      name: 'Download',
+      text: 'Click Export to download your print-ready chess diagram instantly — no watermarks, no sign-up.'
+    }
+  ]
+};
+
+/**
+ * BreadcrumbList schema for /export.
+ */
+export const EXPORT_BREADCRUMB_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  '@id': `${SITE_URL}/export#breadcrumb`,
+  itemListElement: [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'ChessVision',
+      item: `${SITE_URL}/`
+    },
+    {
+      '@type': 'ListItem',
+      position: 2,
+      name: 'Export Chess Diagram',
+      item: `${SITE_URL}/export`
+    }
+  ]
+};
+
+/**
+ * BreadcrumbList schema for /advanced-fen.
+ */
+export const ADVANCED_FEN_BREADCRUMB_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  '@id': `${SITE_URL}/advanced-fen#breadcrumb`,
+  itemListElement: [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: 'ChessVision',
+      item: `${SITE_URL}/`
+    },
+    {
+      '@type': 'ListItem',
+      position: 2,
+      name: 'Batch FEN Export',
+      item: `${SITE_URL}/advanced-fen`
     }
   ]
 };


### PR DESCRIPTION
Closes #155

## What & why

Several SEO fundamentals were missing, hurting search visibility:

- **Per-page H1** — added an `sr-only` h1 to Home, About, Export, and Advanced FEN so each route has exactly one top-level heading for crawlers.
- **Structured data** — added `HowTo` and `BreadcrumbList` schema for `/export`, and a breadcrumb for `/advanced-fen`, opening up rich-result eligibility.
- **Removed fabricated aggregateRating** — the schema shipped a hardcoded 5-star / 1-review rating; Google penalizes self-serving review markup, so it's gone.
- **Consistent metadata** — routed the export page through `getRouteSeo` and expanded the document title to include descriptive keywords.

## Checklist

- [x] `pnpm validate` passes locally
- [x] No visual change (h1s are `sr-only`)