### PR TITLE
ci(triage): skip waiting-triage label for maintainer-authored issues and PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,7 +3,8 @@ name: PR Labeler
 # Auto-labels pull requests based on changed file paths.
 # Type labels (bug, enhancement, etc.) are applied by the separate
 # "Label by PR title" job below, derived from the Conventional Commit title.
-# status: waiting triage is applied to every newly opened PR.
+# "status: waiting triage" is applied to newly opened PRs from contributors —
+# maintainer-authored PRs (OWNER / MEMBER) are skipped.
 #
 # Uses pull_request_target so labeling works for fork PRs.
 # The base repo token is used; PR code is never checked out.
@@ -80,7 +81,11 @@ jobs:
   triage:
     name: Mark new PRs for triage
     runs-on: ubuntu-latest
-    if: github.event.action == 'opened'
+    # Skip PRs opened by a repo owner or org member — already triaged.
+    if: >-
+      github.event.action == 'opened' &&
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'MEMBER'
     steps:
       - uses: actions/github-script@v8
         with:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,10 @@
 name: Issue Triage
 
-# Applies status: needs-triage to every newly opened issue so nothing falls
-# through without a maintainer review.
+# Applies "status: waiting triage" to newly opened issues so contributor
+# reports don't fall through without a maintainer review.
+#
+# Maintainer-authored issues (OWNER / MEMBER) are skipped — the maintainer has
+# already triaged anything they open themselves.
 
 on:
   issues:
@@ -12,8 +15,12 @@ permissions:
 
 jobs:
   label:
-    name: Apply needs-triage
+    name: Apply waiting triage
     runs-on: ubuntu-latest
+    # Skip issues opened by a repo owner or org member.
+    if: >-
+      github.event.issue.author_association != 'OWNER' &&
+      github.event.issue.author_association != 'MEMBER'
     steps:
       - uses: actions/github-script@v8
         with:


### PR DESCRIPTION
## What & why

When the maintainer opens an issue or PR, the auto-triage workflows applied `status: waiting triage` — but the maintainer has already triaged anything they open themselves, so the label was pure noise on their own items.

Both the issue-triage job (`triage.yml`) and the PR-triage job (`labeler.yml`) now skip when `author_association` is `OWNER` or `MEMBER`. Contributor-authored issues and PRs still get the label as before.

No linked issue — this is a CI/infrastructure change.

## Checklist

- [x] Both workflows gated on `author_association`
- [x] Contributor behaviour unchanged