### PR TITLE
chore(templates): polish issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,6 +25,20 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area (optional)
+      description: Which part of the app? Leave blank if unsure.
+      options:
+        - Board editor / drag & drop
+        - FEN input or history
+        - Image export (PNG / JPEG / SVG)
+        - Database search
+        - Accounts / cloud sync
+        - Theme / appearance
+        - Other / not sure
+
   - type: input
     id: environment
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -22,6 +22,20 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area (optional)
+      description: Which part of the app would this touch? Leave blank if unsure.
+      options:
+        - Board editor / drag & drop
+        - FEN input or history
+        - Image export (PNG / JPEG / SVG)
+        - Database search
+        - Accounts / cloud sync
+        - Theme / appearance
+        - Other / not sure
+
   - type: textarea
     id: context
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,11 @@
-Closes #<!-- issue number required -->
+Closes #<!-- issue number — required (use "Refs #" if it doesn't fully close one) -->
 
 ## What & why
 
-<!-- What changed and why. Keep it short — one paragraph is enough. -->
+<!-- What changed and why. One short paragraph is enough. -->
 
 ## Checklist
 
 - [ ] `pnpm validate` passes locally
-- [ ] Screenshots or screen recording attached for any UI change
 - [ ] No `any` / `@ts-ignore` / non-null `!` introduced
+- [ ] Screenshots or a screen recording added — only if this changes the UI


### PR DESCRIPTION
No linked issue — general polish of the GitHub templates.

## What & why

Small touch-ups to make triage faster without adding burden on whoever's filing:

- Bug and feature forms get an optional **Area** dropdown (board / FEN / export / database search / sync / theme), so issues land in the right place without us having to ask follow-up questions. It's optional, so it never blocks someone who just wants to report quickly.
- The PR checklist now asks for screenshots **only when the change touches the UI**, instead of on every PR.

Security and the issue config are left as-is — they were already fine.

## Checklist

- [x] `pnpm validate` passes locally
- [x] No `any` / `@ts-ignore` / non-null `!` introduced
- [ ] Screenshots or a screen recording added — only if this changes the UI