### PR TITLE
fix(env): read Vite env vars with dot notation so they survive the build

### DIFF
--- a/src/features/auth/services/supabaseClient.ts
+++ b/src/features/auth/services/supabaseClient.ts
@@ -2,9 +2,14 @@ import { createClient } from '@supabase/supabase-js';
 
 import { logger } from '@utils';
 
-let supabaseUrl: string = import.meta.env['VITE_SUPABASE_URL'] || '';
+// Dot notation is REQUIRED: Vite only statically inlines `import.meta.env`
+// access written this way. Bracket notation (env['VITE_…']) is left untouched by
+// the build, so in production it resolves to undefined and the client silently
+// falls back to the placeholder URL — breaking auth, sync, and DB search even
+// though the secrets are present at build time.
+let supabaseUrl: string = import.meta.env.VITE_SUPABASE_URL || '';
 const supabaseAnonKey: string =
-  import.meta.env['VITE_SUPABASE_ANON_KEY'] || 'placeholder';
+  import.meta.env.VITE_SUPABASE_ANON_KEY || 'placeholder';
 
 // Validate that the URL is a valid HTTP/HTTPS URL, otherwise Supabase will crash on initialization.
 if (!supabaseUrl.startsWith('http://') && !supabaseUrl.startsWith('https://')) {

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -81,8 +81,10 @@ const HomePage: React.FC = () => {
 
   // Use VITE_SUPABASE_URL to construct the absolute URL to the Edge Function.
   // We cannot use SITE_URL/api/og because Nginx does not proxy it by default.
+  // Dot notation so Vite inlines the value at build time — bracket notation is
+  // left untouched and resolves to undefined in production (see supabaseClient).
   const supabaseUrl =
-    import.meta.env['VITE_SUPABASE_URL']?.replace(/\/$/, '') ||
+    import.meta.env.VITE_SUPABASE_URL?.replace(/\/$/, '') ||
     'https://placeholder.supabase.co';
   const dynamicOgImage = isCustomFen
     ? `${supabaseUrl}/functions/v1/og-image${dynamicParams}`

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,21 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-pwa/client" />
 
+// Typed client env vars. Read these with DOT notation only
+// (`import.meta.env.VITE_SUPABASE_URL`) — Vite statically inlines dot access at
+// build time; bracket access is NOT replaced and resolves to undefined in
+// production. All VITE_-prefixed vars ship to the browser, so they are public.
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL?: string;
+  readonly VITE_SUPABASE_ANON_KEY?: string;
+  readonly VITE_APP_NAME?: string;
+  readonly VITE_APP_VERSION?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 interface Window {
   requestIdleCallback?: (callback: () => void) => number;
 }


### PR DESCRIPTION
Closes #172

## What & why

Supabase config was read as `import.meta.env['VITE_SUPABASE_URL']`. Vite only inlines **dot-notation** env access at build time, so the bracket form was never replaced and resolved to `undefined` in production — every Supabase call fell back to `placeholder.supabase.co`, so database search, accounts, and cloud sync were dead on the live site while working fine in dev. Switched the three reads (`supabaseClient.ts` ×2, `HomePage.tsx` ×1) to dot notation and added typed `ImportMetaEnv` keys. Verified a production build now bakes the real URL into the bundle (the old build shipped no Supabase URL at all).

## Checklist

- [x] `pnpm validate` passes locally
- [x] No `any` / `@ts-ignore` / non-null `!` introduced
- [ ] Screenshots or a screen recording added — only if this changes the UI