### PR TITLE
ci(labels): stop the labeler from flapping and dropping type labels

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -31,11 +31,19 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml
-          sync-labels: true
+          # Additive only — never strip labels. With sync-labels: true the path
+          # job removed any label not in labeler.yml, which raced the title job
+          # below and silently deleted its type labels (Bug/enhancement/chore) on
+          # synchronize/edit. Labels are only ever added now; removing them is a
+          # maintainer's call, not the bot's.
+          sync-labels: false
 
   type:
     name: Label by PR title
     runs-on: ubuntu-latest
+    # The type label comes from the title, which only changes on open/edit —
+    # skip synchronize (new commits) so we don't re-run for nothing.
+    if: github.event.action != 'synchronize'
     steps:
       - name: Map Conventional Commit type to label
         uses: actions/github-script@v8


### PR DESCRIPTION
Closes #174

## What & why

The PR Labeler ran `actions/labeler` with `sync-labels: true`, which strips any label outside its own path config (`area:*`, `dependencies`, `documentation`). Running in parallel with the title-based type job, it raced and deleted the `Bug`/`enhancement`/`chore` label that job had just added — the visible add-then-remove flapping, and why PR #173 ended up with only `area: auth` and no `Bug`.

Now the labeler is additive only (`sync-labels: false`), so it never removes a label another job or a maintainer applied — removing labels is a maintainer's call, which is what large projects do. The title job also skips `synchronize` events, since the title can't change when you only push a commit.

## Checklist

- [x] `pnpm validate` passes locally
- [x] No `any` / `@ts-ignore` / non-null `!` introduced
- [ ] Screenshots or a screen recording added — only if this changes the UI