### PR TITLE
fix(auth): show sign-in failures at form level, not under the password

### DIFF
--- a/src/pages/AuthPage/pages/SignInPage.tsx
+++ b/src/pages/AuthPage/pages/SignInPage.tsx
@@ -20,12 +20,18 @@ export function SignInPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [emailError, setEmailError] = useState('');
   const [passwordError, setPasswordError] = useState('');
+  // Server/sign-in errors (wrong credentials, network, anything from Supabase)
+  // belong at the form level, NOT under the password field — otherwise a network
+  // or server failure reads as "your password is wrong" even when it's correct
+  // (the original symptom in #134, which traced back to the missing Supabase env).
+  const [formError, setFormError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const validate = (): boolean => {
     let valid = true;
     setEmailError('');
     setPasswordError('');
+    setFormError('');
 
     if (!email.trim()) {
       setEmailError('Email is required.');
@@ -55,7 +61,10 @@ export function SignInPage() {
       });
 
       if (signInError) {
-        setPasswordError(getAuthErrorMessage(signInError));
+        // A failed sign-in is a form-level outcome (wrong credentials are about
+        // the email+password pair, not the password alone; network/server
+        // failures aren't about the inputs at all).
+        setFormError(getAuthErrorMessage(signInError));
         return;
       }
 
@@ -95,6 +104,15 @@ export function SignInPage() {
         noValidate
         className="flex flex-col gap-4"
       >
+        {formError && (
+          <div
+            role="alert"
+            className="rounded-lg border border-error/30 bg-error/10 px-3 py-2.5 text-sm text-error"
+          >
+            {formError}
+          </div>
+        )}
+
         <div>
           <label
             htmlFor="signin-email"


### PR DESCRIPTION
Closes #134

## What & why

#134 reported a password validation error on sign-in even with the correct password. The real trigger was the missing Supabase env (fixed in #173) — sign-in was hitting `placeholder.supabase.co`, failing, and that failure was shown under the password field, so it read as "wrong password".

This fixes the UX side so it can't mislead again: input-specific problems (empty/invalid email, empty password) stay under their own field, and anything that comes back from the sign-in call — wrong credentials, network, or server errors — now shows in a form-level alert above the fields instead of pinned to the password input. The alert uses `role="alert"` for screen readers.

## Checklist

- [x] `pnpm validate` passes locally
- [x] No `any` / `@ts-ignore` / non-null `!` introduced
- [ ] Screenshots or a screen recording added — only if this changes the UI