### PR TITLE
fix(board): drop text placeholder on piece SVG load failure

### DIFF
--- a/src/shared/hooks/usePieceImages.ts
+++ b/src/shared/hooks/usePieceImages.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { PIECE_MAP } from '@constants';
 
-import { logger, preloadPieceStyle, setCachedPieces } from '@utils';
+import { logger, preloadPieceStyle } from '@utils';
 
 /**
  * Loads and caches all piece images for the given piece style.
@@ -63,24 +63,17 @@ export function usePieceImages(pieceStyle: string): {
             if (img) {
               images[key] = img;
             } else {
-              images[key] = createPlaceholderImage(key);
               missingCount++;
             }
           });
 
-          // A partial load miss is already handled gracefully by substituting
-          // placeholders — do NOT raise a user-facing error overlay for it.
-          // Only a TOTAL failure, where no real piece loaded at all, is worth
-          // surfacing. Partial misses are logged for diagnostics and the cache
-          // is seeded with placeholders.
           if (missingCount > 0) {
-            setCachedPieces(styleToLoad, images);
             const totalPieces = Object.keys(PIECE_MAP).length;
             if (missingCount === totalPieces) {
               setError('Failed to load pieces');
             } else {
               logger.warn(
-                `usePieceImages: ${missingCount}/${totalPieces} pieces fell back to placeholders for style "${styleToLoad}"`
+                `usePieceImages: ${missingCount}/${totalPieces} pieces failed to load for style "${styleToLoad}"`
               );
             }
           }
@@ -111,42 +104,4 @@ export function usePieceImages(pieceStyle: string): {
   // All four fields are state that change together, so memoizing the wrapper
   // object would never preserve a stable reference — return it directly.
   return { pieceImages, isLoading, error, loadProgress };
-}
-
-/**
- * Creates a 100×100 canvas placeholder image labelled with the piece name,
- * used when the real SVG fails to load.
- *
- * @param pieceName - Piece key used as the label (e.g. `'wP'`)
- * @returns An `HTMLImageElement` with a data-URL src
- */
-function createPlaceholderImage(pieceName: string): HTMLImageElement {
-  logger.log('Creating placeholder for:', pieceName);
-  const canvas = document.createElement('canvas');
-  canvas.width = 100;
-  canvas.height = 100;
-  const ctx = canvas.getContext('2d');
-
-  if (ctx) {
-    ctx.fillStyle = '#f0f0f0';
-    ctx.fillRect(0, 0, 100, 100);
-    ctx.strokeStyle = '#999999';
-    ctx.lineWidth = 2;
-    ctx.strokeRect(5, 5, 90, 90);
-    ctx.fillStyle = '#666666';
-    ctx.font = 'bold 20px Arial';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText(pieceName, 50, 50);
-  }
-
-  try {
-    const img = new Image();
-    img.src = canvas.toDataURL();
-    return img;
-  } finally {
-    // Release the backing canvas memory after encoding (Safari does not GC it).
-    canvas.width = 0;
-    canvas.height = 0;
-  }
 }

--- a/src/shared/utils/pieceImageCache.ts
+++ b/src/shared/utils/pieceImageCache.ts
@@ -95,19 +95,3 @@ export async function preloadPieceStyle(
   await Promise.all(promises);
   return result;
 }
-
-/**
- * Manually adds images to the cache for a style.
- *
- * @param style - The piece style name
- * @param pieces - Map of piece keys to image elements
- */
-export function setCachedPieces(
-  style: string,
-  pieces: Record<string, HTMLImageElement>
-): void {
-  Object.entries(pieces).forEach(([key, img]) => {
-    pieceCache.set(`${style}_${key}`, img);
-  });
-  enforceCacheCap();
-}


### PR DESCRIPTION
Closes #201

## What & why

When a piece SVG failed to load, `usePieceImages` fell back to `createPlaceholderImage()` — a canvas function that drew the piece key (`wB`, `bQ`…) as text and passed it as a real image. Under resource pressure, after cache eviction triggered a re-fetch that errored, users occasionally saw raw notation strings on the board instead of piece graphics.

Removed `createPlaceholderImage()` and the now-unused `setCachedPieces()` export. Failed pieces are omitted from the image map; `DraggablePiece` already returns `null` when `pieceImage` is missing, so the square renders empty with no visible artefact.

## Checklist

- [x] `pnpm validate` passes locally
- [x] No `any` / `@ts-ignore` / non-null `!` introduced
- [ ] Screenshots or a screen recording added — only if this changes the UI