### PR TITLE
fix(layout): keep About/Settings rail and separator fixed while content scrolls

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -458,9 +458,16 @@ html[data-reduced-motion='reduce'] ::view-transition-new(root) {
     font-variant-numeric: tabular-nums;
   }
 
+  /* No `contain: layout` and no `overflow-x` here. Layout containment makes
+     #root the containing block for every `position: fixed` descendant, so the
+     navbar (and any fixed overlay) scrolls away with the document below lg.
+     `overflow-x: hidden` silently computes overflow-y to `auto`, turning #root
+     into a scrollport that never scrolls — which disables every `sticky`
+     descendant (the About/Settings rail). Horizontal clipping is already owned
+     by `html` and `body` (overflow-x: hidden + max-width: 100vw) above. */
   #root {
-    @apply overflow-x-hidden w-full max-w-full;
-    contain: layout style;
+    @apply w-full max-w-full;
+    contain: style;
   }
 
   button {

--- a/src/pages/AboutPage/AboutPage.tsx
+++ b/src/pages/AboutPage/AboutPage.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   Code2,
@@ -71,6 +71,7 @@ const AboutPage = memo(function AboutPage() {
       : DEFAULT_TAB;
 
   const [activeTab, setActiveTab] = useState(initialTab);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   // Redirect an unknown tab key to the default so old/bad links land on a valid
   // section instead of an empty area.
@@ -94,27 +95,29 @@ const AboutPage = memo(function AboutPage() {
     (tabId: string) => {
       setActiveTab(tabId);
       setSearchParams({ tab: tabId });
+      // Each section starts at its top, not wherever the previous one was left.
+      contentRef.current?.scrollTo({ top: 0 });
     },
     [setSearchParams]
   );
 
   return (
-    <div
-      data-page-scroll
-      className="min-h-full bg-bg md:h-full md:max-h-full md:overflow-y-auto"
-    >
+    <div className="min-h-full bg-bg md:h-full md:max-h-full">
       <Seo
         {...getRouteSeo('/about')}
         schema={[WEBSITE_SCHEMA, ORGANIZATION_SCHEMA]}
       />
       <h1 className="sr-only">About ChessVision</h1>
-      {/* Two-column shell, constrained to the navbar's width so the page reads
-          as one column under the bar: a sticky left category rail (always
-          visible, never collapses) and a scrolling content column on the right
-          (GitHub-settings pattern), mirroring the Settings page layout. */}
-      <div className="page-container flex flex-col gap-6 py-6 sm:py-10 md:flex-row md:gap-8 lg:gap-10">
-        <div className="shrink-0 mb-6 md:mb-0 md:border-r md:border-border md:pr-8 md:w-52 lg:w-56">
-          <div className="md:sticky md:top-10">
+      {/* Two-column split pane, constrained to the navbar's width so the page
+          reads as one column under the bar (GitHub-settings pattern, mirroring
+          the Settings page layout). At lg+ the shell locks the outer page, the
+          row fills the visible height and ONLY the right content column
+          scrolls — the rail and the separator stay put. Below lg the window
+          scrolls and the rail falls back to `sticky`, offset past the fixed
+          navbar. */}
+      <div className="page-container flex flex-col gap-6 py-6 sm:py-10 md:h-full md:min-h-0 md:flex-row md:gap-8 lg:gap-10">
+        <div className="shrink-0 mb-6 md:mb-0 md:w-52 lg:w-56">
+          <div className="md:sticky md:top-[calc(var(--navbar-height)+1.5rem)]">
             <PageTabs
               groups={groups}
               activeId={activeTab}
@@ -124,13 +127,23 @@ const AboutPage = memo(function AboutPage() {
           </div>
         </div>
 
+        {/* Separator as its own flex child (not a border on the rail): at lg+
+            it spans the row's padded content box, so it starts below the navbar
+            and stops above the bottom instead of running edge to edge. */}
+        <div
+          aria-hidden="true"
+          className="hidden md:block w-px shrink-0 self-stretch bg-border"
+        />
+
         {/* Scroll region, NOT a landmark: the app shell already owns the single
             `<main id="main-content">`. A second `<main>` is an ARIA landmark
             violation (1.3.1). `role="region"` + label keeps it navigable. */}
         <div
+          ref={contentRef}
+          data-page-scroll
           role="region"
           aria-label="About content"
-          className="min-w-0 flex-1"
+          className="min-w-0 flex-1 md:min-h-0 lg:overflow-y-auto"
         >
           {activeTab === 'about' && <AboutMainSection />}
           {activeTab === 'changelog' && <ChangelogSection />}

--- a/src/pages/SettingsPage/SettingsPage.tsx
+++ b/src/pages/SettingsPage/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   Accessibility,
@@ -72,6 +72,7 @@ const SettingsPage = memo(function SettingsPage() {
     requestedTab && validTabIds.has(requestedTab) ? requestedTab : defaultTab;
 
   const [activeTab, setActiveTab] = useState(initialTab);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   // Redirect a retired tab key (e.g. ?tab=developer, ?tab=export) to the default
   // tab so old bookmarks land on a valid section instead of an empty area.
@@ -95,6 +96,8 @@ const SettingsPage = memo(function SettingsPage() {
     (tabId: string) => {
       setActiveTab(tabId);
       setSearchParams({ tab: tabId });
+      // Each section starts at its top, not wherever the previous one was left.
+      contentRef.current?.scrollTo({ top: 0 });
     },
     [setSearchParams]
   );
@@ -104,18 +107,17 @@ const SettingsPage = memo(function SettingsPage() {
     .find((item) => item.id === activeTab)?.label;
 
   return (
-    <div
-      data-page-scroll
-      className="min-h-full bg-bg md:h-full md:max-h-full md:overflow-y-auto"
-    >
+    <div className="min-h-full bg-bg md:h-full md:max-h-full">
       <Seo name={activeTabLabel} noindex />
-      {/* Two-column shell, constrained to the navbar's width so the page reads
-          as one column under the bar: a sticky left section rail (always
-          visible, never collapses) and a scrolling content column on the right
-          (GitHub-settings pattern). */}
-      <div className="page-container flex flex-col gap-6 py-6 sm:py-8 md:flex-row md:gap-8 lg:gap-10">
-        <div className="shrink-0 mb-6 md:mb-0 md:border-r md:border-border md:pr-8 md:w-52 lg:w-56">
-          <div className="md:sticky md:top-8">
+      {/* Two-column split pane, constrained to the navbar's width so the page
+          reads as one column under the bar (GitHub-settings pattern). At lg+
+          the shell locks the outer page, the row fills the visible height and
+          ONLY the right content column scrolls — the rail and the separator
+          stay put. Below lg the window scrolls and the rail falls back to
+          `sticky`, offset past the fixed navbar. */}
+      <div className="page-container flex flex-col gap-6 py-6 sm:py-8 md:h-full md:min-h-0 md:flex-row md:gap-8 lg:gap-10">
+        <div className="shrink-0 mb-6 md:mb-0 md:w-52 lg:w-56">
+          <div className="md:sticky md:top-[calc(var(--navbar-height)+1.5rem)]">
             <PageTabs
               groups={groups}
               activeId={activeTab}
@@ -125,10 +127,24 @@ const SettingsPage = memo(function SettingsPage() {
           </div>
         </div>
 
+        {/* Separator as its own flex child (not a border on the rail): at lg+
+            it spans the row's padded content box, so it starts below the navbar
+            and stops above the bottom instead of running edge to edge. */}
+        <div
+          aria-hidden="true"
+          className="hidden md:block w-px shrink-0 self-stretch bg-border"
+        />
+
         {/* Scroll region, NOT a landmark: the app shell already owns the single
             `<main id="main-content">`. A second `<main>` is an ARIA landmark
             violation (1.3.1). `role="region"` + label keeps it navigable. */}
-        <div role="region" aria-label="Settings" className="min-w-0 flex-1">
+        <div
+          ref={contentRef}
+          data-page-scroll
+          role="region"
+          aria-label="Settings"
+          className="min-w-0 flex-1 md:min-h-0 lg:overflow-y-auto"
+        >
           {activeTab === 'profile' && <AccountSection />}
           {activeTab === 'appearance' && <AppearanceSection />}
           {activeTab === 'board' && <BoardSection />}


### PR DESCRIPTION
Closes #203

## What & why

On About and Settings the left rail and the vertical separator scrolled away with the page. Two root causes: the pages' own `md:overflow-y-auto` wrapper never actually scrolls below `lg` (the window does) yet still became the sticky rail's scrollport, so `sticky` never engaged; and `#root`'s `contain: layout` plus the implicit `overflow-y: auto` from `overflow-x: hidden` broke `position: fixed`/`sticky` app-wide below `lg` (the fixed navbar itself scrolled off screen). At `lg+` the pages now use a true split pane — the row fills the visible height and only the right content column scrolls — so the rail and separator cannot move; the separator is its own flex child spanning the row's padded content box, so it starts below the navbar and stops above the bottom as requested. Below `lg` the rail falls back to `sticky` offset past the fixed navbar (now working thanks to the `#root` fix). `data-page-scroll` moved to the content column so keyboard paging keeps working, and switching tabs resets the column's scroll.

## Checklist

- [x] `pnpm validate` passes locally
- [x] No `any` / `@ts-ignore` / non-null `!` introduced
- [ ] Screenshots or a screen recording added — only if this changes the UI
