### PR TITLE
fix: show real exported file size instead of estimate

### DIFF
--- a/src/components/features/Export/ExportProgress.tsx
+++ b/src/components/features/Export/ExportProgress.tsx
@@ -6,6 +6,7 @@ import {
   type ExportConfig,
   type ExportInfo,
   type FileSizeEstimates,
+  formatFileSize,
   getExportInfo
 } from '@utils';
 import { ModalShell } from '@ui';
@@ -22,6 +23,7 @@ interface ExportProgressProps {
   onResume?: () => void;
   onCancel?: () => void;
   isPaused?: boolean;
+  actualBytes?: number | null;
 }
 
 export const ExportProgress = memo(function ExportProgress({
@@ -34,7 +36,8 @@ export const ExportProgress = memo(function ExportProgress({
   onPause,
   onResume,
   onCancel,
-  isPaused
+  isPaused,
+  actualBytes
 }: ExportProgressProps) {
   const [displayProgress, setDisplayProgress] = useState(0);
 
@@ -87,9 +90,15 @@ export const ExportProgress = memo(function ExportProgress({
           <div className="text-xs text-text-muted bg-surface-elevated border border-border rounded-lg px-3 py-2 space-y-1">
             <div>Resolution: {exportInfo.displaySize}</div>
             <div>
-              File size estimate:{' '}
-              {exportInfo.fileSizeEstimates[format] ||
-                exportInfo.fileSizeEstimates['png']}
+              {actualBytes != null ? (
+                <>File size: {formatFileSize(actualBytes)}</>
+              ) : (
+                <>
+                  File size estimate: ~
+                  {exportInfo.fileSizeEstimates[format] ||
+                    exportInfo.fileSizeEstimates['png']}
+                </>
+              )}
             </div>
             {exportInfo.isLargeExport && (
               <div className="text-warning mt-1">

--- a/src/components/features/Export/ExportProgress.tsx
+++ b/src/components/features/Export/ExportProgress.tsx
@@ -70,6 +70,15 @@ export const ExportProgress = memo(function ExportProgress({
     exportInfo = null;
   }
 
+  const estimatedSize = exportInfo
+    ? exportInfo.fileSizeEstimates[format] ||
+      exportInfo.fileSizeEstimates['png']
+    : '';
+  const fileSizeText =
+    actualBytes != null
+      ? `File size: ${formatFileSize(actualBytes)}`
+      : `File size estimate: ~${estimatedSize}`;
+
   return (
     <ModalShell
       isOpen={isExporting}
@@ -89,17 +98,7 @@ export const ExportProgress = memo(function ExportProgress({
         {exportInfo && (
           <div className="text-xs text-text-muted bg-surface-elevated border border-border rounded-lg px-3 py-2 space-y-1">
             <div>Resolution: {exportInfo.displaySize}</div>
-            <div>
-              {actualBytes != null ? (
-                <>File size: {formatFileSize(actualBytes)}</>
-              ) : (
-                <>
-                  File size estimate: ~
-                  {exportInfo.fileSizeEstimates[format] ||
-                    exportInfo.fileSizeEstimates['png']}
-                </>
-              )}
-            </div>
+            <div>{fileSizeText}</div>
             {exportInfo.isLargeExport && (
               <div className="text-warning mt-1">
                 Large export (RAM: {exportInfo.memoryEstimateMB} MB). May take

--- a/src/pages/AdvancedFENInputPage/utils/advancedExportHelpers.ts
+++ b/src/pages/AdvancedFENInputPage/utils/advancedExportHelpers.ts
@@ -5,8 +5,8 @@ export const runFormatExport = async (
   config: ExportConfig,
   name: string,
   onProg: (p: number) => void
-) => {
-  if (format === 'png') return downloadPNG(config, name, onProg);
-  if (format === 'jpeg') return downloadJPEG(config, name, onProg);
-  return downloadSVG(config, name, onProg);
+): Promise<void> => {
+  if (format === 'png') await downloadPNG(config, name, onProg);
+  else if (format === 'jpeg') await downloadJPEG(config, name, onProg);
+  else await downloadSVG(config, name, onProg);
 };

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -111,6 +111,7 @@ const HomePage: React.FC = () => {
             currentFormat={home.exportState.currentFormat || ''}
             config={home.getExportConfig()}
             isPaused={home.exportState.isPaused}
+            actualBytes={home.exportState.actualBytes}
             onClose={home.toggleProgress}
             onPause={home.handlePause}
             onResume={home.handleResume}

--- a/src/shared/hooks/useHomeExport.ts
+++ b/src/shared/hooks/useHomeExport.ts
@@ -20,6 +20,7 @@ export interface ExportState {
   currentFormat: string | null;
   isPaused: boolean;
   showProgress: boolean;
+  actualBytes: number | null;
 }
 
 interface BatchExportOverrides {
@@ -53,7 +54,8 @@ export function useHomeExport(opts: UseHomeExportOptions) {
     exportProgress: 0,
     currentFormat: null,
     isPaused: false,
-    showProgress: true
+    showProgress: true,
+    actualBytes: null
   });
 
   const pieceImagesRef = useRef<Record<string, HTMLImageElement>>({});
@@ -101,7 +103,8 @@ export function useHomeExport(opts: UseHomeExportOptions) {
         isExporting: false,
         currentFormat: null,
         exportProgress: 0,
-        isPaused: false
+        isPaused: false,
+        actualBytes: null
       }));
       completeTimerRef.current = null;
     }, 300);
@@ -123,7 +126,7 @@ export function useHomeExport(opts: UseHomeExportOptions) {
       config: ExportConfig,
       filename: string,
       cb: (p: number) => void
-    ) => Promise<void>,
+    ) => Promise<number>,
     label: string
   ) => {
     if (!validateFEN(opts.fen)) {
@@ -136,15 +139,17 @@ export function useHomeExport(opts: UseHomeExportOptions) {
       isExporting: true,
       currentFormat: format,
       exportProgress: 0,
-      isPaused: false
+      isPaused: false,
+      actualBytes: null
     }));
     opts.saveExportFen(opts.fen);
 
     try {
       const config = getExportConfig();
-      await runner(config, opts.fileName, (progress) => {
+      const bytes = await runner(config, opts.fileName, (progress) => {
         setExportState((prev) => ({ ...prev, exportProgress: progress }));
       });
+      setExportState((prev) => ({ ...prev, actualBytes: bytes }));
       opts.notify.success(`${label} downloaded`);
     } catch (err) {
       notifyError(err, label);
@@ -218,7 +223,8 @@ export function useHomeExport(opts: UseHomeExportOptions) {
       isExporting: false,
       currentFormat: null,
       exportProgress: 0,
-      isPaused: false
+      isPaused: false,
+      actualBytes: null
     }));
     opts.notify.info('Export cancelled');
   };

--- a/src/shared/utils/canvasExporter.ts
+++ b/src/shared/utils/canvasExporter.ts
@@ -90,11 +90,12 @@ async function downloadRaster(
   format: 'png' | 'jpeg',
   extension: string,
   onProgress?: ProgressCallback
-): Promise<void> {
+): Promise<number> {
   try {
     const finalBlob = await getRasterBlob(config, format, onProgress);
     saveBlob(finalBlob, fileName, extension);
     setProgress(onProgress, 100, 'Done');
+    return finalBlob.size;
   } catch (error: unknown) {
     if (error instanceof Error && error.message === 'Export cancelled') {
       throw new Error('Export cancelled', { cause: error });
@@ -110,7 +111,7 @@ export function downloadPNG(
   config: ExportConfig,
   fileName: string,
   onProgress?: ProgressCallback
-): Promise<void> {
+): Promise<number> {
   return downloadRaster(config, fileName, 'png', 'png', onProgress);
 }
 
@@ -118,7 +119,7 @@ export function downloadJPEG(
   config: ExportConfig,
   fileName: string,
   onProgress?: ProgressCallback
-): Promise<void> {
+): Promise<number> {
   return downloadRaster(config, fileName, 'jpeg', 'jpg', onProgress);
 }
 

--- a/src/shared/utils/exportState.ts
+++ b/src/shared/utils/exportState.ts
@@ -100,8 +100,7 @@ export function getExportInfo(config: ExportConfig): ExportInfo {
   const mode = getExportMode(exportQuality);
   const fileSizes = estimateFileSizes(
     exportSize.canvasWidth,
-    exportSize.canvasHeight,
-    exportQuality
+    exportSize.canvasHeight
   );
 
   return {

--- a/src/shared/utils/imageOptimizer.test.ts
+++ b/src/shared/utils/imageOptimizer.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { estimateFileSizes, formatFileSize } from './imageOptimizer';
+
+test('formatFileSize scales unit with magnitude', () => {
+  assert.equal(formatFileSize(512), '512 B');
+  assert.equal(formatFileSize(2048), '2 KB');
+  assert.equal(formatFileSize(5 * 1024 * 1024), '5.0 MB');
+});
+
+test('estimateFileSizes stays positive and grows with resolution', () => {
+  const small = estimateFileSizes(1000, 1000, 1);
+  const large = estimateFileSizes(4000, 4000, 1);
+
+  assert.ok(small.pngBytes > 0);
+  assert.ok(small.jpegBytes > 0);
+  assert.ok(large.pngBytes > small.pngBytes);
+  assert.ok(large.jpegBytes > small.jpegBytes);
+});
+
+test('estimateFileSizes bytes-per-pixel falls as the image grows', () => {
+  const small = estimateFileSizes(1000, 1000, 1);
+  const large = estimateFileSizes(4000, 4000, 1);
+
+  const smallBpp = small.pngBytes / (1000 * 1000);
+  const largeBpp = large.pngBytes / (4000 * 4000);
+
+  assert.ok(largeBpp < smallBpp);
+});

--- a/src/shared/utils/imageOptimizer.test.ts
+++ b/src/shared/utils/imageOptimizer.test.ts
@@ -10,8 +10,8 @@ test('formatFileSize scales unit with magnitude', () => {
 });
 
 test('estimateFileSizes stays positive and grows with resolution', () => {
-  const small = estimateFileSizes(1000, 1000, 1);
-  const large = estimateFileSizes(4000, 4000, 1);
+  const small = estimateFileSizes(1000, 1000);
+  const large = estimateFileSizes(4000, 4000);
 
   assert.ok(small.pngBytes > 0);
   assert.ok(small.jpegBytes > 0);
@@ -20,8 +20,8 @@ test('estimateFileSizes stays positive and grows with resolution', () => {
 });
 
 test('estimateFileSizes bytes-per-pixel falls as the image grows', () => {
-  const small = estimateFileSizes(1000, 1000, 1);
-  const large = estimateFileSizes(4000, 4000, 1);
+  const small = estimateFileSizes(1000, 1000);
+  const large = estimateFileSizes(4000, 4000);
 
   const smallBpp = small.pngBytes / (1000 * 1000);
   const largeBpp = large.pngBytes / (4000 * 4000);

--- a/src/shared/utils/imageOptimizer.ts
+++ b/src/shared/utils/imageOptimizer.ts
@@ -50,7 +50,7 @@ export function shouldForceCoordinateBorder(quality: number): boolean {
   return !!findQualityPreset(quality)?.forceCoordinateBorder;
 }
 
-function formatFileSize(bytes: number): string {
+export function formatFileSize(bytes: number): string {
   if (bytes < 1024) return Math.round(bytes) + ' B';
   if (bytes < 1024 * 1024) return Math.round(bytes / 1024) + ' KB';
   return (bytes / 1024 / 1024).toFixed(1) + ' MB';
@@ -167,14 +167,17 @@ export interface FileSizeEstimates {
 export function estimateFileSizes(
   width: number,
   height: number,
-  exportQuality: number
+  _exportQuality: number
 ): FileSizeEstimates {
   const pixels = width * height;
-  const mode = getExportMode(exportQuality);
-  const pngFactor = mode === 'print' ? 0.05 : 0.08;
-  const jpegFactor = mode === 'print' ? 0.04 : 0.06;
-  const pngBytes = Math.round(pixels * pngFactor);
-  const jpegBytes = Math.round(pixels * jpegFactor);
+  // A chess diagram is mostly flat colour, so bytes-per-pixel falls as the
+  // image grows (larger flat runs compress better). Modelling the encoded
+  // size as proportional to sqrt(pixels) tracks that far more closely than a
+  // fixed bytes-per-pixel factor. Coefficients fitted against real PNG/JPEG
+  // (q=0.92) exports of coordinate boards across export sizes.
+  const scale = Math.sqrt(pixels);
+  const pngBytes = Math.round(scale * 90);
+  const jpegBytes = Math.round(scale * 55);
   return {
     png: formatFileSize(pngBytes),
     jpeg: formatFileSize(jpegBytes),

--- a/src/shared/utils/imageOptimizer.ts
+++ b/src/shared/utils/imageOptimizer.ts
@@ -166,16 +166,9 @@ export interface FileSizeEstimates {
 
 export function estimateFileSizes(
   width: number,
-  height: number,
-  _exportQuality: number
+  height: number
 ): FileSizeEstimates {
-  const pixels = width * height;
-  // A chess diagram is mostly flat colour, so bytes-per-pixel falls as the
-  // image grows (larger flat runs compress better). Modelling the encoded
-  // size as proportional to sqrt(pixels) tracks that far more closely than a
-  // fixed bytes-per-pixel factor. Coefficients fitted against real PNG/JPEG
-  // (q=0.92) exports of coordinate boards across export sizes.
-  const scale = Math.sqrt(pixels);
+  const scale = Math.sqrt(width * height);
   const pngBytes = Math.round(scale * 90);
   const jpegBytes = Math.round(scale * 55);
   return {


### PR DESCRIPTION
Closes #187

## What & why

The export modal computed the shown file size from a fixed bytes-per-pixel factor, which ignores how a chess diagram actually compresses. A board is mostly flat colour, so PNG/JPEG shrink it far more than that factor assumed, and the displayed value drifted well away from the file that ended up on disk. Now the encoded blob's real size is threaded back to the modal and shown as the true "File size" once ready; until the blob exists, the pre-encode estimate scales with `sqrt(pixels)` so bytes-per-pixel falls as the image grows, and its label is prefixed with `~` to read as an estimate. The batch (Advanced FEN) flow keeps the estimate label since it produces a ZIP of many positions where a single-file size doesn't apply.

## Checklist

- [x] `pnpm validate` passes locally
- [x] No `any` / `@ts-ignore` / non-null `!` introduced
- [ ] Screenshots or a screen recording added — only if this changes the UI