### PR TITLE
fix: play piece entrance animation only on first load

### DIFF
--- a/src/components/interactions/Board/components/DroppableSquare.tsx
+++ b/src/components/interactions/Board/components/DroppableSquare.tsx
@@ -1,9 +1,10 @@
-import { memo, useCallback, useRef } from 'react';
+import { memo, useCallback } from 'react';
 
 import type { PieceSymbol } from '@app-types';
 import { indicesToSquare, pieceToName } from '@utils';
 import { useDroppable } from '@hooks';
 import { DraggablePiece } from './DraggablePiece';
+import { shouldAnimateEntrance } from './entranceAnimation';
 
 interface DroppableSquareProps {
   row: number;
@@ -38,10 +39,8 @@ export const DroppableSquare = memo(
     cellSize = 64
   }: DroppableSquareProps) {
     const bgColor = isLight ? lightColor : darkColor;
-    const wasLoadingRef = useRef(isLoading);
-    const initialDelay =
-      wasLoadingRef.current && !isLoading ? `${(row * 8 + col) * 6}ms` : '0ms';
-    if (wasLoadingRef.current && !isLoading) wasLoadingRef.current = false;
+    const animateEntrance = !isLoading && shouldAnimateEntrance();
+    const entranceDelay = animateEntrance ? `${(row * 8 + col) * 6}ms` : '0ms';
 
     const squareName = indicesToSquare(row, col);
     const ariaLabel = piece
@@ -94,11 +93,13 @@ export const DroppableSquare = memo(
         {piece && pieceImage && !isLoading && (
           <div
             key={piece}
-            className="w-full h-full flex items-center justify-center animate-piece-in"
+            className={`w-full h-full flex items-center justify-center${
+              animateEntrance ? ' animate-piece-in' : ''
+            }`}
             style={{
               contain: 'layout style',
               opacity: isHeldSource ? 0.45 : 1,
-              animationDelay: initialDelay
+              animationDelay: entranceDelay
             }}
           >
             <DraggablePiece

--- a/src/components/interactions/Board/components/InteractiveBoard.tsx
+++ b/src/components/interactions/Board/components/InteractiveBoard.tsx
@@ -4,6 +4,7 @@ import type { PieceSymbol } from '@app-types';
 
 import { describeBoardPosition, getPieceKey } from '@utils';
 import { DroppableSquare } from './DroppableSquare';
+import { markEntrancePlayed } from './entranceAnimation';
 import { useBoardKeyboard } from '../hooks/useBoardKeyboard';
 
 // Types
@@ -60,6 +61,10 @@ export const InteractiveBoard = memo(function InteractiveBoard({
     ...(onPieceDrop ? { onPieceDrop } : {}),
     ...(onPieceRemove ? { onPieceRemove } : {})
   });
+
+  useEffect(() => {
+    if (!isLoading) markEntrancePlayed();
+  }, [isLoading]);
 
   useEffect(() => {
     if (!onKeyboardApi) return;

--- a/src/components/interactions/Board/components/entranceAnimation.ts
+++ b/src/components/interactions/Board/components/entranceAnimation.ts
@@ -1,0 +1,9 @@
+let hasPlayed = false;
+
+export function shouldAnimateEntrance() {
+  return !hasPlayed;
+}
+
+export function markEntrancePlayed() {
+  hasPlayed = true;
+}


### PR DESCRIPTION
Closes #186

So when you leave the home page and come back the pieces animate in again every single time, which looks off because they are already sitting there. It should only happen on the very first load.

The reason was the flag that decides whether to animate was kept in a component-local useRef. Everytime you navigate away the board unmounts and when you come back it mounts fresh, so the ref resets and the code thinks its the first load again.

I moved that state out into a small module-scoped flag in entranceAnimation.ts so it survives the remount for the whole session. Now the animation plays once on the initial load, and after that the board just renders statically no matter how many times you revisit it.