### PR TITLE
feat: click to place pieces from palette

### DIFF
--- a/src/components/interactions/Board/components/DroppableSquare.tsx
+++ b/src/components/interactions/Board/components/DroppableSquare.tsx
@@ -17,6 +17,7 @@ interface DroppableSquareProps {
   isSelected?: boolean;
   isCursor?: boolean;
   isHeldSource?: boolean;
+  isPlaceTarget?: boolean;
   isLoading: boolean;
   cellSize?: number;
 }
@@ -34,6 +35,7 @@ export const DroppableSquare = memo(
     isSelected = false,
     isCursor = false,
     isHeldSource = false,
+    isPlaceTarget = false,
     isLoading,
     cellSize = 64
   }: DroppableSquareProps) {
@@ -79,7 +81,9 @@ export const DroppableSquare = memo(
         role="gridcell"
         aria-label={ariaLabel}
         aria-selected={isSelected || isCursor}
-        className="w-full h-full flex items-center justify-center relative cursor-pointer"
+        className={`w-full h-full flex items-center justify-center relative cursor-pointer ${
+          isPlaceTarget ? 'group' : ''
+        }`}
         style={{
           backgroundColor: bgColor,
           zIndex: ringShadow ? 2 : 0,
@@ -124,6 +128,20 @@ export const DroppableSquare = memo(
             }}
           />
         )}
+        {isPlaceTarget && !ringShadow && (
+          <div
+            aria-hidden="true"
+            className="opacity-0 group-hover:opacity-100 transition-opacity"
+            style={{
+              position: 'absolute',
+              inset: 0,
+              border: '2px solid var(--color-text-primary)',
+              boxSizing: 'border-box',
+              pointerEvents: 'none',
+              zIndex: 3
+            }}
+          />
+        )}
       </div>
     );
   },
@@ -140,6 +158,7 @@ export const DroppableSquare = memo(
       prevProps.isSelected === nextProps.isSelected &&
       prevProps.isCursor === nextProps.isCursor &&
       prevProps.isHeldSource === nextProps.isHeldSource &&
+      prevProps.isPlaceTarget === nextProps.isPlaceTarget &&
       prevProps.pieceImage === nextProps.pieceImage &&
       prevProps.cellSize === nextProps.cellSize
     );

--- a/src/components/interactions/Board/components/InteractiveBoard.tsx
+++ b/src/components/interactions/Board/components/InteractiveBoard.tsx
@@ -9,6 +9,7 @@ import { useBoardKeyboard } from '../hooks/useBoardKeyboard';
 // Types
 export interface BoardKeyboardApi {
   pickUpFromPalette: (piece: PieceSymbol) => void;
+  clearHeld: () => void;
 }
 
 interface InteractiveBoardProps {
@@ -28,6 +29,7 @@ interface InteractiveBoardProps {
   ) => void;
   onSquareSelect?: ((row: number, col: number) => void) | undefined;
   selectedSquare?: readonly [number, number] | null | undefined;
+  paletteActive?: boolean;
   onPieceRemove?: ((row: number, col: number) => void) | undefined;
   onKeyboardApi?: ((api: BoardKeyboardApi) => void) | undefined;
 }
@@ -42,6 +44,7 @@ export const InteractiveBoard = memo(function InteractiveBoard({
   onPieceDrop,
   onSquareSelect,
   selectedSquare,
+  paletteActive = false,
   onPieceRemove,
   onKeyboardApi
 }: InteractiveBoardProps) {
@@ -53,7 +56,8 @@ export const InteractiveBoard = memo(function InteractiveBoard({
     announcement,
     onKeyDown,
     onBlur,
-    pickUpFromPalette
+    pickUpFromPalette,
+    clearHeld
   } = useBoardKeyboard({
     board,
     flipped,
@@ -67,9 +71,10 @@ export const InteractiveBoard = memo(function InteractiveBoard({
       pickUpFromPalette: (piece: PieceSymbol) => {
         pickUpFromPalette(piece);
         boardRef.current?.focus();
-      }
+      },
+      clearHeld
     });
-  }, [onKeyboardApi, pickUpFromPalette]);
+  }, [onKeyboardApi, pickUpFromPalette, clearHeld]);
 
   const squares = useMemo(() => {
     const result = [];
@@ -102,6 +107,7 @@ export const InteractiveBoard = memo(function InteractiveBoard({
             pieceImage={pieceImage}
             onSelect={onSquareSelect}
             isSelected={isSelected}
+            isPlaceTarget={paletteActive}
             isCursor={isCursor}
             isHeldSource={isHeldSource}
             isLoading={isLoading}
@@ -120,7 +126,8 @@ export const InteractiveBoard = memo(function InteractiveBoard({
     onSquareSelect,
     selectedSquare,
     cursor,
-    heldFrom
+    heldFrom,
+    paletteActive
   ]);
 
   const boardDescription = useMemo(

--- a/src/components/interactions/Board/hooks/useBoardKeyboard.ts
+++ b/src/components/interactions/Board/hooks/useBoardKeyboard.ts
@@ -36,6 +36,7 @@ export interface UseBoardKeyboardResult {
   onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   onBlur: () => void;
   pickUpFromPalette: (piece: PieceSymbol) => void;
+  clearHeld: () => void;
 }
 
 export function useBoardKeyboard({
@@ -193,6 +194,8 @@ export function useBoardKeyboard({
     [announce, flipped]
   );
 
+  const clearHeld = useCallback(() => setHeld(null), []);
+
   const activeDescendantId = cursor
     ? `sq-${cursor.row}-${cursor.col}`
     : undefined;
@@ -206,7 +209,8 @@ export function useBoardKeyboard({
       announcement,
       onKeyDown,
       onBlur,
-      pickUpFromPalette
+      pickUpFromPalette,
+      clearHeld
     }),
     [
       cursor,
@@ -215,7 +219,8 @@ export function useBoardKeyboard({
       announcement,
       onKeyDown,
       onBlur,
-      pickUpFromPalette
+      pickUpFromPalette,
+      clearHeld
     ]
   );
 }

--- a/src/components/interactions/Editor/components/ChessEditor.tsx
+++ b/src/components/interactions/Editor/components/ChessEditor.tsx
@@ -111,7 +111,8 @@ export const ChessEditor = memo(function ChessEditor({
     });
   }, [handlePieceRemove]);
 
-  const clearSelection = useCallback(() => setSelectedSquare(null), []);
+  const [selectedPalettePiece, setSelectedPalettePiece] =
+    useState<PieceSymbol | null>(null);
 
   const boardKeyboardApiRef = useRef<BoardKeyboardApi | null>(null);
   const handleKeyboardApi = useCallback((api: BoardKeyboardApi) => {
@@ -120,6 +121,34 @@ export const ChessEditor = memo(function ChessEditor({
   const handlePalettePick = useCallback((piece: PieceSymbol) => {
     boardKeyboardApiRef.current?.pickUpFromPalette(piece);
   }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelectedSquare(null);
+    setSelectedPalettePiece(null);
+    boardKeyboardApiRef.current?.clearHeld();
+  }, []);
+
+  const handlePaletteSelect = useCallback((piece: PieceSymbol) => {
+    setSelectedPalettePiece((prev) => (prev === piece ? null : piece));
+  }, []);
+
+  const handleBoardSquareSelect = useCallback(
+    (row: number, col: number) => {
+      if (selectedPalettePiece) {
+        handlePieceDrop(
+          selectedPalettePiece,
+          undefined,
+          undefined,
+          row,
+          col,
+          true
+        );
+        return;
+      }
+      handleSquareSelect(row, col);
+    },
+    [selectedPalettePiece, handlePieceDrop, handleSquareSelect]
+  );
 
   useEffect(() => {
     syncFromFen(fen);
@@ -231,8 +260,9 @@ export const ChessEditor = memo(function ChessEditor({
                       isLoading={isLoading}
                       flipped={flipped}
                       onPieceDrop={handlePieceDrop}
-                      onSquareSelect={handleSquareSelect}
+                      onSquareSelect={handleBoardSquareSelect}
                       selectedSquare={selectedSquare}
+                      paletteActive={selectedPalettePiece !== null}
                       onPieceRemove={handlePieceRemove}
                       onKeyboardApi={handleKeyboardApi}
                     />
@@ -304,6 +334,8 @@ export const ChessEditor = memo(function ChessEditor({
                 pieceImages={pieceImages}
                 isLoading={isLoading}
                 onKeyboardPick={handlePalettePick}
+                selectedPiece={selectedPalettePiece}
+                onSelect={handlePaletteSelect}
               />
             </div>
             <div className={styles.editorDisplayOpts}>

--- a/src/components/interactions/PiecePalette/PiecePalette.tsx
+++ b/src/components/interactions/PiecePalette/PiecePalette.tsx
@@ -13,6 +13,8 @@ export interface PiecePaletteProps {
   isLoading: boolean;
   className?: string;
   onKeyboardPick?: ((piece: PieceSymbol) => void) | undefined;
+  selectedPiece?: PieceSymbol | null | undefined;
+  onSelect?: ((piece: PieceSymbol) => void) | undefined;
 }
 
 interface PalettePiece {
@@ -34,18 +36,25 @@ export const PiecePalette = memo(function PiecePalette({
   pieceImages,
   isLoading,
   className = '',
-  onKeyboardPick
+  onKeyboardPick,
+  selectedPiece,
+  onSelect
 }: PiecePaletteProps) {
   const renderStackedPiece = useCallback(
     (p: PalettePiece) => {
       const imageKey = getPieceKey(p.piece);
       const pieceImage = imageKey ? (pieceImages[imageKey] ?? null) : null;
       const disabled = isLoading || !pieceImage;
+      const isSelected = selectedPiece === p.piece;
       return (
         <button
           key={p.id}
           type="button"
           disabled={disabled}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect?.(p.piece);
+          }}
           onKeyDown={(e) => {
             if (disabled) return;
             if (e.key === 'Enter' || e.key === ' ') {
@@ -54,8 +63,9 @@ export const PiecePalette = memo(function PiecePalette({
             }
           }}
           aria-label={`Place ${p.name}`}
+          aria-pressed={isSelected}
           title={p.name}
-          className={`${styles.stackedPieceBtn} ${isLoading ? 'opacity-50' : ''}`}
+          className={`${styles.stackedPieceBtn} ${isSelected ? styles.selected : ''} ${isLoading ? 'opacity-50' : ''}`}
         >
           <DraggablePiece
             piece={p.piece}
@@ -67,7 +77,7 @@ export const PiecePalette = memo(function PiecePalette({
         </button>
       );
     },
-    [pieceImages, isLoading, onKeyboardPick]
+    [pieceImages, isLoading, onKeyboardPick, selectedPiece, onSelect]
   );
 
   const renderFlatPiece = useCallback(
@@ -75,11 +85,16 @@ export const PiecePalette = memo(function PiecePalette({
       const imageKey = getPieceKey(p.piece);
       const pieceImage = imageKey ? (pieceImages[imageKey] ?? null) : null;
       const disabled = isLoading || !pieceImage;
+      const isSelected = selectedPiece === p.piece;
       return (
         <button
           key={p.id}
           type="button"
           disabled={disabled}
+          onClick={(e) => {
+            e.stopPropagation();
+            onSelect?.(p.piece);
+          }}
           onKeyDown={(e) => {
             if (disabled) return;
             if (e.key === 'Enter' || e.key === ' ') {
@@ -88,8 +103,9 @@ export const PiecePalette = memo(function PiecePalette({
             }
           }}
           aria-label={`Place ${p.name}`}
+          aria-pressed={isSelected}
           title={p.name}
-          className={`${styles.flatPieceBtn} ${isLoading ? 'opacity-50' : ''}`}
+          className={`${styles.flatPieceBtn} ${isSelected ? styles.selected : ''} ${isLoading ? 'opacity-50' : ''}`}
         >
           <DraggablePiece
             piece={p.piece}
@@ -101,7 +117,7 @@ export const PiecePalette = memo(function PiecePalette({
         </button>
       );
     },
-    [pieceImages, isLoading, onKeyboardPick]
+    [pieceImages, isLoading, onKeyboardPick, selectedPiece, onSelect]
   );
 
   return (

--- a/src/components/interactions/PiecePalette/styles/piece-palette.module.scss
+++ b/src/components/interactions/PiecePalette/styles/piece-palette.module.scss
@@ -107,6 +107,14 @@
     outline: none;
     box-shadow: 0 0 0 2px var(--color-accent);
   }
+
+  &.selected,
+  &.selected:hover,
+  &.selected:focus-visible {
+    background-color: var(--color-surface-hover);
+    border-color: var(--color-text-primary);
+    box-shadow: 0 0 0 1px var(--color-text-primary);
+  }
 }
 
 .flatPieceBtn {
@@ -134,5 +142,12 @@
   &:focus-visible {
     outline: none;
     box-shadow: 0 0 0 2px var(--color-accent);
+  }
+
+  &.selected,
+  &.selected:hover,
+  &.selected:focus-visible {
+    background-color: var(--color-surface-elevated);
+    box-shadow: 0 0 0 1px var(--color-text-primary);
   }
 }

--- a/src/components/interactions/PiecePalette/styles/piece-palette.module.scss.d.ts
+++ b/src/components/interactions/PiecePalette/styles/piece-palette.module.scss.d.ts
@@ -10,6 +10,7 @@ declare const styles: {
   readonly flatGroup: string;
   readonly flatSep: string;
   readonly flatPieceBtn: string;
+  readonly selected: string;
 };
 
 export default styles;

--- a/src/shared/hooks/useDragDrop.ts
+++ b/src/shared/hooks/useDragDrop.ts
@@ -1,6 +1,8 @@
 import { createContext, useCallback, useContext, useRef } from 'react';
 import type { ChessDragData } from '@constants';
 
+const DRAG_THRESHOLD = 5;
+
 export interface DragSession {
   dragData: ChessDragData;
   ghost: HTMLDivElement;
@@ -47,6 +49,10 @@ export function useDraggable({
   const { active, _startDrag } = useDragContext();
   const dataRef = useRef(data);
   dataRef.current = data;
+  const imageSrcRef = useRef(imageSrc);
+  imageSrcRef.current = imageSrc;
+  const disabledRef = useRef(disabled);
+  disabledRef.current = disabled;
 
   const isDragging =
     !!active &&
@@ -60,43 +66,80 @@ export function useDraggable({
       if (disabled || !imageSrc) return;
       if (e.pointerType === 'mouse' && e.button !== 0) return;
 
-      e.stopPropagation();
-      e.preventDefault();
+      const el = e.currentTarget as HTMLElement;
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const pointerId = e.pointerId;
+      let started = false;
 
-      const size = cellSize * 0.9;
-      const half = size / 2;
+      // Capture immediately so we keep receiving moves even if the pointer
+      // leaves this element before the drag threshold is crossed.
+      el.setPointerCapture(pointerId);
 
-      const ghost = document.createElement('div');
-      ghost.setAttribute('aria-hidden', 'true');
-      ghost.style.cssText = [
-        `position:fixed`,
-        `top:0`,
-        `left:0`,
-        `width:${size}px`,
-        `height:${size}px`,
-        `pointer-events:none`,
-        `z-index:9999`,
-        `will-change:transform`,
-        `transform:translate(${e.clientX - half}px,${e.clientY - half}px)`
-      ].join(';');
+      const begin = (clientX: number, clientY: number) => {
+        // Props may have changed mid-gesture (e.g. a piece-style reload flips
+        // isLoading); bail if the piece is no longer draggable.
+        const src = imageSrcRef.current;
+        if (disabledRef.current || !src) return;
+        started = true;
+        const size = cellSize * 0.9;
+        const half = size / 2;
 
-      const img = document.createElement('img');
-      img.src = imageSrc;
-      img.draggable = false;
-      img.style.cssText = [
-        'width:100%',
-        'height:100%',
-        'object-fit:contain',
-        'opacity:0.9',
-        'filter:drop-shadow(0 2px 6px rgba(0,0,0,0.4))',
-        'pointer-events:none',
-        'user-select:none',
-        '-webkit-user-select:none'
-      ].join(';');
-      ghost.appendChild(img);
+        const ghost = document.createElement('div');
+        ghost.setAttribute('aria-hidden', 'true');
+        ghost.style.cssText = [
+          `position:fixed`,
+          `top:0`,
+          `left:0`,
+          `width:${size}px`,
+          `height:${size}px`,
+          `pointer-events:none`,
+          `z-index:9999`,
+          `will-change:transform`,
+          `transform:translate(${clientX - half}px,${clientY - half}px)`
+        ].join(';');
 
-      _startDrag({ dragData: dataRef.current, ghost, halfSize: half });
-      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+        const img = document.createElement('img');
+        img.src = src;
+        img.draggable = false;
+        img.style.cssText = [
+          'width:100%',
+          'height:100%',
+          'object-fit:contain',
+          'opacity:0.9',
+          'filter:drop-shadow(0 2px 6px rgba(0,0,0,0.4))',
+          'pointer-events:none',
+          'user-select:none',
+          '-webkit-user-select:none'
+        ].join(';');
+        ghost.appendChild(img);
+
+        _startDrag({ dragData: dataRef.current, ghost, halfSize: half });
+      };
+
+      const onMove = (ev: PointerEvent) => {
+        if (started) return;
+        if (
+          Math.hypot(ev.clientX - startX, ev.clientY - startY) > DRAG_THRESHOLD
+        ) {
+          begin(ev.clientX, ev.clientY);
+          // Only suppress scroll/selection once a real drag has actually
+          // started; a plain tap never reaches here, so click still fires.
+          if (started) ev.preventDefault();
+        }
+      };
+
+      const cleanup = () => {
+        el.removeEventListener('pointermove', onMove);
+        el.removeEventListener('pointerup', cleanup);
+        el.removeEventListener('pointercancel', cleanup);
+        if (el.hasPointerCapture(pointerId))
+          el.releasePointerCapture(pointerId);
+      };
+
+      el.addEventListener('pointermove', onMove, { passive: false });
+      el.addEventListener('pointerup', cleanup);
+      el.addEventListener('pointercancel', cleanup);
     },
     [disabled, imageSrc, cellSize, _startDrag]
   );

--- a/src/shared/hooks/useDragDrop.ts
+++ b/src/shared/hooks/useDragDrop.ts
@@ -72,13 +72,9 @@ export function useDraggable({
       const pointerId = e.pointerId;
       let started = false;
 
-      // Capture immediately so we keep receiving moves even if the pointer
-      // leaves this element before the drag threshold is crossed.
       el.setPointerCapture(pointerId);
 
       const begin = (clientX: number, clientY: number) => {
-        // Props may have changed mid-gesture (e.g. a piece-style reload flips
-        // isLoading); bail if the piece is no longer draggable.
         const src = imageSrcRef.current;
         if (disabledRef.current || !src) return;
         started = true;
@@ -120,13 +116,11 @@ export function useDraggable({
       const onMove = (ev: PointerEvent) => {
         if (started) return;
         if (
-          Math.hypot(ev.clientX - startX, ev.clientY - startY) > DRAG_THRESHOLD
-        ) {
-          begin(ev.clientX, ev.clientY);
-          // Only suppress scroll/selection once a real drag has actually
-          // started; a plain tap never reaches here, so click still fires.
-          if (started) ev.preventDefault();
-        }
+          Math.hypot(ev.clientX - startX, ev.clientY - startY) <= DRAG_THRESHOLD
+        )
+          return;
+        begin(ev.clientX, ev.clientY);
+        if (started) ev.preventDefault();
       };
 
       const cleanup = () => {


### PR DESCRIPTION
Closes #147

Before you can only drag pieces from the palette to the board. On phone this is hard and not so precise. So i add click to place too.

Now you click a piece in the palette, then click a square and the piece go there. The piece stay selected so you can put many of them fast. To stop, click the same piece again or press Escape. When a piece is selected it have a outline, and when you hover a square you see where it will go.

For this i also change the drag a little. Now the drag only start after you move the pointer a bit. So a normal click dont start a drag anymore and the piece dont jump when you click it. Real drag with mouse and touch still work like before.

I test it on desktop and on a small phone size. Select from palette, click to place one or many, Escape to stop, old mouse drag and touch drag, all works. Keyboard is not changed. typecheck, lint and build are green.
