### PR TITLE
fix: unify board preview design with ChessEditor across AdvancedFEN and ExportPage

### DIFF
--- a/src/components/features/BoardStyle/DisplayOptions.tsx
+++ b/src/components/features/BoardStyle/DisplayOptions.tsx
@@ -24,7 +24,7 @@ function DisplayOptionsComponent({
   setApplyToAll
 }: DisplayOptionsProps) {
   return (
-    <div className="space-y-3">
+    <div className="space-y-1">
       {!hideLabel && (
         <label className="block text-sm font-semibold text-text-secondary mb-3">
           Display Options

--- a/src/components/interactions/Board/components/DroppableSquare.tsx
+++ b/src/components/interactions/Board/components/DroppableSquare.tsx
@@ -18,7 +18,6 @@ interface DroppableSquareProps {
   isSelected?: boolean;
   isCursor?: boolean;
   isHeldSource?: boolean;
-  isPlaceTarget?: boolean;
   isLoading: boolean;
   cellSize?: number;
 }
@@ -36,7 +35,6 @@ export const DroppableSquare = memo(
     isSelected = false,
     isCursor = false,
     isHeldSource = false,
-    isPlaceTarget = false,
     isLoading,
     cellSize = 64
   }: DroppableSquareProps) {
@@ -62,16 +60,6 @@ export const DroppableSquare = memo(
       data: { row, col }
     });
 
-    const ringShadow = isOver
-      ? 'inset 0 0 0 3px rgba(255, 255, 255, 0.5)'
-      : isCursor
-        ? 'inset 0 0 0 3px var(--color-accent), inset 0 0 0 5px rgba(0,0,0,0.35)'
-        : isSelected
-          ? 'inset 0 0 0 2px var(--color-text-primary)'
-          : isHeldSource
-            ? 'inset 0 0 0 3px var(--color-accent)'
-            : null;
-
     return (
       <div
         ref={setNodeRef}
@@ -80,16 +68,14 @@ export const DroppableSquare = memo(
         role="gridcell"
         aria-label={ariaLabel}
         aria-selected={isSelected || isCursor}
-        className={`w-full h-full flex items-center justify-center relative cursor-pointer ${
-          isPlaceTarget ? 'group' : ''
-        }`}
+        className="w-full h-full flex items-center justify-center relative cursor-pointer"
         style={{
           backgroundColor: bgColor,
-          zIndex: ringShadow ? 2 : 0,
-          contain: 'layout style',
+          outline: 'none',
+          boxShadow: isOver ? 'inset 0 0 0 1px rgba(255,255,255,0.8)' : 'none',
+          zIndex: isOver ? 2 : 0,
           minWidth: 0,
-          minHeight: 0,
-          outline: `0.5px solid ${bgColor}`
+          minHeight: 0
         }}
         data-row={row}
         data-col={col}
@@ -117,32 +103,6 @@ export const DroppableSquare = memo(
             />
           </div>
         )}
-        {ringShadow && (
-          <div
-            aria-hidden="true"
-            style={{
-              position: 'absolute',
-              inset: 0,
-              boxShadow: ringShadow,
-              pointerEvents: 'none',
-              zIndex: 3
-            }}
-          />
-        )}
-        {isPlaceTarget && !ringShadow && (
-          <div
-            aria-hidden="true"
-            className="opacity-0 group-hover:opacity-100 transition-opacity"
-            style={{
-              position: 'absolute',
-              inset: 0,
-              border: '2px solid var(--color-text-primary)',
-              boxSizing: 'border-box',
-              pointerEvents: 'none',
-              zIndex: 3
-            }}
-          />
-        )}
       </div>
     );
   },
@@ -159,7 +119,6 @@ export const DroppableSquare = memo(
       prevProps.isSelected === nextProps.isSelected &&
       prevProps.isCursor === nextProps.isCursor &&
       prevProps.isHeldSource === nextProps.isHeldSource &&
-      prevProps.isPlaceTarget === nextProps.isPlaceTarget &&
       prevProps.pieceImage === nextProps.pieceImage &&
       prevProps.cellSize === nextProps.cellSize
     );

--- a/src/components/interactions/Board/components/InteractiveBoard.tsx
+++ b/src/components/interactions/Board/components/InteractiveBoard.tsx
@@ -30,7 +30,6 @@ interface InteractiveBoardProps {
   ) => void;
   onSquareSelect?: ((row: number, col: number) => void) | undefined;
   selectedSquare?: readonly [number, number] | null | undefined;
-  paletteActive?: boolean;
   onPieceRemove?: ((row: number, col: number) => void) | undefined;
   onKeyboardApi?: ((api: BoardKeyboardApi) => void) | undefined;
 }
@@ -45,7 +44,6 @@ export const InteractiveBoard = memo(function InteractiveBoard({
   onPieceDrop,
   onSquareSelect,
   selectedSquare,
-  paletteActive = false,
   onPieceRemove,
   onKeyboardApi
 }: InteractiveBoardProps) {
@@ -112,7 +110,6 @@ export const InteractiveBoard = memo(function InteractiveBoard({
             pieceImage={pieceImage}
             onSelect={onSquareSelect}
             isSelected={isSelected}
-            isPlaceTarget={paletteActive}
             isCursor={isCursor}
             isHeldSource={isHeldSource}
             isLoading={isLoading}
@@ -131,8 +128,7 @@ export const InteractiveBoard = memo(function InteractiveBoard({
     onSquareSelect,
     selectedSquare,
     cursor,
-    heldFrom,
-    paletteActive
+    heldFrom
   ]);
 
   const boardDescription = useMemo(
@@ -163,7 +159,7 @@ export const InteractiveBoard = memo(function InteractiveBoard({
         data-arrow-keys="self"
         onKeyDown={onKeyDown}
         onBlur={onBlur}
-        className="grid grid-cols-8 grid-rows-8 overflow-hidden w-full h-full outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+        className="grid grid-cols-8 grid-rows-8 overflow-hidden w-full h-full"
         style={{
           gap: 0,
           zIndex: 1,

--- a/src/components/interactions/Editor/components/ChessEditor.tsx
+++ b/src/components/interactions/Editor/components/ChessEditor.tsx
@@ -16,7 +16,7 @@ import {
 } from '@hooks';
 import type { PieceSymbol } from '@app-types';
 
-import { Checkbox } from '@ui';
+import { DisplayOptions } from '@components/features';
 import {
   type BoardKeyboardApi,
   InteractiveBoard,
@@ -75,8 +75,7 @@ export const ChessEditor = memo(function ChessEditor({
   className = ''
 }: ChessEditorProps) {
   const { pieceImages, isLoading } = usePieceImages(pieceStyle);
-  const { boardSize, cellSize, containerRef, boardElementRef } =
-    useEditorBoardSize();
+  const { boardSize, containerRef, boardElementRef } = useEditorBoardSize();
 
   const {
     board,
@@ -317,8 +316,7 @@ export const ChessEditor = memo(function ChessEditor({
             className={styles.editorPanel}
             style={
               {
-                '--board-h': `${boardSize}px`,
-                paddingBottom: showCoords ? `${cellSize * 8 * 0.05}px` : '0'
+                '--board-h': `${boardSize}px`
               } as CSSProperties
             }
           >
@@ -339,23 +337,13 @@ export const ChessEditor = memo(function ChessEditor({
               />
             </div>
             <div className={styles.editorDisplayOpts}>
-              <span className={styles.editorDisplayOptsLabel}>
-                Display Options
-              </span>
-              <div className={styles.editorDisplayOptsChecks}>
-                <Checkbox
-                  checked={showCoords}
-                  onChange={(e) => setShowCoords?.(e.target.checked)}
-                  label="Show Coordinates"
-                  className="p-1!"
-                />
-                <Checkbox
-                  checked={showThinFrame}
-                  onChange={(e) => setShowThinFrame?.(e.target.checked)}
-                  label="Show Board Frame"
-                  className="p-1!"
-                />
-              </div>
+              <DisplayOptions
+                showCoords={showCoords}
+                setShowCoords={setShowCoords ?? (() => {})}
+                showThinFrame={showThinFrame ?? false}
+                setShowThinFrame={setShowThinFrame ?? (() => {})}
+                hideLabel={true}
+              />
             </div>
             <div className={styles.editorDbSearch}>
               <DatabaseSearchPanel

--- a/src/components/interactions/Editor/components/ChessEditor.tsx
+++ b/src/components/interactions/Editor/components/ChessEditor.tsx
@@ -261,7 +261,6 @@ export const ChessEditor = memo(function ChessEditor({
                       onPieceDrop={handlePieceDrop}
                       onSquareSelect={handleBoardSquareSelect}
                       selectedSquare={selectedSquare}
-                      paletteActive={selectedPalettePiece !== null}
                       onPieceRemove={handlePieceRemove}
                       onKeyboardApi={handleKeyboardApi}
                     />

--- a/src/components/interactions/PiecePalette/styles/piece-palette.module.scss
+++ b/src/components/interactions/PiecePalette/styles/piece-palette.module.scss
@@ -103,17 +103,10 @@
     }
   }
 
-  &:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 2px var(--color-accent);
-  }
-
   &.selected,
-  &.selected:hover,
-  &.selected:focus-visible {
+  &.selected:hover {
     background-color: var(--color-surface-hover);
     border-color: var(--color-text-primary);
-    box-shadow: 0 0 0 1px var(--color-text-primary);
   }
 }
 
@@ -139,15 +132,9 @@
     }
   }
 
-  &:focus-visible {
-    outline: none;
-    box-shadow: 0 0 0 2px var(--color-accent);
-  }
-
   &.selected,
-  &.selected:hover,
-  &.selected:focus-visible {
+  &.selected:hover {
     background-color: var(--color-surface-elevated);
-    box-shadow: 0 0 0 1px var(--color-text-primary);
+    border: 1px solid var(--color-text-primary);
   }
 }

--- a/src/pages/AdvancedFENInputPage/components/InteractiveBoardColumn.tsx
+++ b/src/pages/AdvancedFENInputPage/components/InteractiveBoardColumn.tsx
@@ -93,7 +93,7 @@ const InteractiveBoardColumn = memo(function InteractiveBoardColumn({
       />
 
       {state.activeTab === 'export-settings' && (
-        <div className="flex items-center justify-center gap-2 flex-wrap select-none mt-1 ml-[9%] w-[91%]">
+        <div className="flex items-center justify-center gap-2 flex-wrap select-none mt-1 ml-[5%] w-[95%]">
           <SummaryBadge label="Size">
             <span className="text-accent">{summaryParts.size}</span>
           </SummaryBadge>
@@ -114,7 +114,7 @@ const InteractiveBoardColumn = memo(function InteractiveBoardColumn({
       )}
 
       {state.validFens.length > 1 && (
-        <div className="ml-[9%] w-[91%]">
+        <div className="ml-[5%] w-[95%]">
           <PlaybackControls
             isPlaying={state.isPlaying}
             interval={state.intervalTime}
@@ -132,7 +132,7 @@ const InteractiveBoardColumn = memo(function InteractiveBoardColumn({
       )}
 
       {state.activeTab === 'preview-style' && (
-        <div className="mt-1 ml-[9%] w-[91%]">
+        <div className="mt-1 ml-[5%] w-[95%]">
           <DisplayOptions
             showCoords={state.showCoordsLocal}
             setShowCoords={handlers.setShowCoordsLocal}

--- a/src/pages/ExportPage/components/BoardPreviewCanvas.tsx
+++ b/src/pages/ExportPage/components/BoardPreviewCanvas.tsx
@@ -15,7 +15,7 @@ import {
 const DEFAULT_LIGHT = BOARD_THEMES['classic']?.light ?? '#f0d9b5';
 const DEFAULT_DARK = BOARD_THEMES['classic']?.dark ?? '#b58863';
 
-const GUTTER_RATIO = 0.09;
+const GUTTER_RATIO = 0.05;
 
 // Types
 interface BoardPreviewCanvasProps {
@@ -143,25 +143,29 @@ const BoardPreviewCanvas = memo(
       boardPx
     ]);
 
+    const ranks = flipped
+      ? ['1', '2', '3', '4', '5', '6', '7', '8']
+      : ['8', '7', '6', '5', '4', '3', '2', '1'];
+    const files = flipped
+      ? ['h', 'g', 'f', 'e', 'd', 'c', 'b', 'a']
+      : ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+
     return (
       <div
         ref={wrapperRef}
-        style={
-          {
-            width: '100%',
-            aspectRatio: '1 / 1',
-            position: 'relative',
-            '--gutter-size': `${gutter}px`
-          } as React.CSSProperties
-        }
+        style={{
+          width: '100%',
+          aspectRatio: '1 / 1',
+          position: 'relative'
+        }}
       >
         <div
           style={{
             position: 'absolute',
-            left: `${gutter}px`,
             top: 0,
-            width: `${boardPx}px`,
-            height: `${boardPx}px`
+            right: 0,
+            width: '95%',
+            height: '95%'
           }}
         >
           <canvas
@@ -169,14 +173,17 @@ const BoardPreviewCanvas = memo(
             aria-hidden="true"
             className={`block transition-opacity duration-200 ${isLoading ? 'opacity-0' : 'opacity-100'}`}
           />
-          <div
-            className="pointer-events-none absolute inset-0 border-[3px] transition-colors duration-200"
-            style={{
-              borderColor: showThinFrame
-                ? (darkSquare ?? DEFAULT_DARK)
-                : 'transparent'
-            }}
-          />
+          {showThinFrame && (
+            <div
+              className="absolute pointer-events-none box-border"
+              style={{
+                inset: '-2.5px',
+                border: `2px solid ${darkSquare ?? DEFAULT_DARK}`,
+                boxShadow: 'inset 0 0 0 0.5px rgba(0,0,0,0.9)',
+                zIndex: 10
+              }}
+            />
+          )}
           {isLoading && (
             <div className="absolute inset-0 flex items-center justify-center bg-surface/60">
               <div className="w-5 h-5 border-2 border-accent border-t-transparent rounded-full animate-spin" />
@@ -191,23 +198,15 @@ const BoardPreviewCanvas = memo(
 
         {showCoords && cellSize > 0 && (
           <div
-            className="flex flex-col text-text-secondary font-bold select-none absolute"
-            style={{
-              left: 0,
-              top: 0,
-              width: `${gutter}px`,
-              height: `${boardPx}px`,
-              fontSize: `max(9px, ${boardPx * 0.028}px)`
-            }}
+            className="absolute top-0 left-0 flex flex-col pr-1"
+            style={{ width: '5%', height: '95%' }}
             aria-hidden="true"
           >
-            {(flipped
-              ? ['1', '2', '3', '4', '5', '6', '7', '8']
-              : ['8', '7', '6', '5', '4', '3', '2', '1']
-            ).map((rank) => (
+            {ranks.map((rank) => (
               <div
                 key={rank}
-                className={`flex items-center justify-end flex-1 ${showThinFrame ? 'pr-2 sm:pr-2.5' : 'pr-1 sm:pr-1.5'}`}
+                className="flex items-center justify-center text-text-secondary font-bold select-none h-[12.5%]"
+                style={{ fontSize: `max(9px, ${boardPx * 0.028}px)` }}
               >
                 {rank}
               </div>
@@ -217,23 +216,15 @@ const BoardPreviewCanvas = memo(
 
         {showCoords && cellSize > 0 && (
           <div
-            className="flex flex-row text-text-secondary font-bold select-none absolute lowercase"
-            style={{
-              left: `${gutter}px`,
-              bottom: 0,
-              width: `${boardPx}px`,
-              height: `${gutter}px`,
-              fontSize: `max(9px, ${boardPx * 0.028}px)`
-            }}
+            className="absolute bottom-0 right-0 flex pt-1"
+            style={{ width: '95%', height: '5%' }}
             aria-hidden="true"
           >
-            {(flipped
-              ? ['h', 'g', 'f', 'e', 'd', 'c', 'b', 'a']
-              : ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
-            ).map((file) => (
+            {files.map((file) => (
               <div
                 key={file}
-                className={`flex items-start justify-center flex-1 ${showThinFrame ? 'pt-2 sm:pt-2.5' : 'pt-1 sm:pt-1.5'}`}
+                className="flex-1 flex items-center justify-center text-text-secondary font-bold select-none lowercase"
+                style={{ fontSize: `max(9px, ${boardPx * 0.028}px)` }}
               >
                 {file}
               </div>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -4,7 +4,7 @@
   }
 
   html {
-    @apply w-full;
+    @apply w-full h-full;
     min-height: 100%;
     max-width: 100vw;
     overflow-x: hidden;
@@ -16,7 +16,7 @@
   }
 
   body {
-    @apply w-full;
+    @apply w-full h-full;
     min-height: 100%;
     overflow-x: hidden;
     overscroll-behavior-y: none;
@@ -53,7 +53,7 @@
   }
 
   #root {
-    @apply overflow-x-hidden w-full max-w-full;
+    @apply overflow-x-hidden w-full max-w-full h-full;
     contain: style;
   }
 


### PR DESCRIPTION
Closes #185

## What & why

Board preview on AdvancedFEN and ExportPage now matches the HomePage editor — gutter, frame, and coordinates are all aligned. Drag hover simplified to a single 1px white inset shadow, palette selection outline thickness bug fixed, focus-visible outlines removed. Coordinate labels no longer shift when toggling the frame, and ChessEditor no longer stretches/compresses when toggling coordinates.

## Checklist
- [x] `pnpm validate` passes locally
- [x] No `any` / `@ts-ignore` / non-null `!` introduced
- [ ] Screenshots or a screen recording added — only if this changes the UI