### PR TITLE
fix: render piece SVGs at export resolution for crisp high-res output

### DIFF
--- a/app/views/helpers/exportSvg.ts
+++ b/app/views/helpers/exportSvg.ts
@@ -30,12 +30,58 @@ const PIECE_KEYS = [
 ] as const;
 
 const MAX_PIECE_STYLE_LENGTH = 40;
+const MIN_PIECE_INTRINSIC_PX = 64;
+const MAX_PIECE_INTRINSIC_PX = 2048;
 
 interface PieceStyleCache {
   [style: string]: { [key: string]: string };
 }
 
 const pieceDataUrlCache: PieceStyleCache = {};
+
+export function calcCanvasWidth(
+  boardSize: number,
+  showCoords: boolean,
+  exportQuality: number,
+  showThinFrame: boolean,
+): number {
+  const safeQ = Number.isFinite(exportQuality) && exportQuality > 0 ? exportQuality : 1;
+  const rawBoard = Math.round((boardSize / 2.54) * 300 * safeQ);
+  const borderSize = showCoords ? Math.round(Math.max(18, Math.min(800, rawBoard * 0.05))) : 0;
+  const frame = showThinFrame ? Math.max(2, Math.round(rawBoard * 0.003)) : 0;
+  const framePad = showThinFrame ? frame * 2 : 0;
+  return Math.round(borderSize + rawBoard + framePad);
+}
+
+export function intrinsicPxOf(svgText: string): number {
+  let maxPx = 0;
+  const re = /\b(?:width|height)\s*=\s*"([0-9.]+)\s*(px|mm|cm|pt)?"/gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(svgText))) {
+    const value = parseFloat(match[1] ?? "");
+    if (!Number.isFinite(value)) continue;
+    const unit = (match[2] ?? "px").toLowerCase();
+    let px = value;
+    if (unit === "mm") px = (value / 25.4) * 96;
+    else if (unit === "cm") px = (value / 2.54) * 96;
+    else if (unit === "pt") px = (value / 72) * 96;
+    maxPx = Math.max(maxPx, px);
+  }
+  return Math.round(maxPx);
+}
+
+export function resizePieceSvg(svgText: string, targetPx: number): string {
+  const size = String(Math.round(targetPx));
+  const resized = svgText.replace(/<svg([^>]*?)>/i, (_match, attrs: string) => {
+    let next = attrs;
+    next = next.replace(/\s+width\s*=\s*"[^"]*"/i, ` width="${size}"`);
+    next = next.replace(/\s+height\s*=\s*"[^"]*"/i, ` height="${size}"`);
+    if (!/\swidth\s*=/.test(next)) next += ` width="${size}"`;
+    if (!/\sheight\s*=/.test(next)) next += ` height="${size}"`;
+    return `<svg${next}>`;
+  });
+  return resized === svgText ? svgText : resized;
+}
 
 export interface BoardSvgConfig {
   fen: string;
@@ -64,28 +110,35 @@ function getPieceKey(fenPiece: string): string | null {
   return (isWhite ? "w" : "b") + fenPiece.toUpperCase();
 }
 
-function readPieceDataUrl(style: string, key: string): string {
+function readPieceDataUrl(style: string, key: string, targetSize: number): string {
   if (!/^[a-z0-9]+$/.test(style) || style.length > MAX_PIECE_STYLE_LENGTH) {
     return "";
   }
   if (!/^[wb][KQRBNP]$/.test(key)) return "";
 
+  const cacheKey = `${key}|${targetSize}`;
   const cache = (pieceDataUrlCache[style] ??= {});
-  if (cache[key]) return cache[key];
+  if (cache[cacheKey]) return cache[cacheKey];
 
   const filePath = join(PUBLIC_DIR, "piece", style, `${key}.svg`);
   try {
     if (!existsSync(filePath)) {
-      cache[key] = "";
+      cache[cacheKey] = "";
       return "";
     }
-    const svg = readFileSync(filePath);
-    const base64 = svg.toString("base64");
+    const svgText = readFileSync(filePath, "utf8");
+    const intrinsic = intrinsicPxOf(svgText);
+    const target = Math.min(
+      MAX_PIECE_INTRINSIC_PX,
+      Math.max(MIN_PIECE_INTRINSIC_PX, intrinsic, targetSize),
+    );
+    const resized = target > intrinsic ? resizePieceSvg(svgText, target) : svgText;
+    const base64 = Buffer.from(resized, "utf8").toString("base64");
     const dataUrl = `data:image/svg+xml;base64,${base64}`;
-    cache[key] = dataUrl;
+    cache[cacheKey] = dataUrl;
     return dataUrl;
   } catch {
-    cache[key] = "";
+    cache[cacheKey] = "";
     return "";
   }
 }
@@ -140,9 +193,15 @@ export function buildBoardSvg(config: BoardSvgConfig): string {
   }
   const board = parsedBoard;
 
+  const canvasWidth = calcCanvasWidth(boardSize, showCoords, exportQuality, showThinFrame);
+  const pieceOutputPx = Math.min(
+    MAX_PIECE_INTRINSIC_PX,
+    Math.max(MIN_PIECE_INTRINSIC_PX, Math.ceil((squarePx / totalWidth) * canvasWidth)),
+  );
+
   const pieceDataURLs: Record<string, string> = {};
   PIECE_KEYS.forEach((key) => {
-    pieceDataURLs[key] = readPieceDataUrl(pieceStyle, key);
+    pieceDataURLs[key] = readPieceDataUrl(pieceStyle, key, pieceOutputPx);
   });
 
   const fontSize = Math.round(Math.max(10, Math.min(480, borderPx * 0.72)));

--- a/tests/exportSvg.test.ts
+++ b/tests/exportSvg.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildBoardSvg,
+  calcCanvasWidth,
+  intrinsicPxOf,
+  resizePieceSvg,
+} from "../app/views/helpers/exportSvg.ts";
+
+const PIECE_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 45 45" width="512" height="512">' +
+  '<rect width="45" height="45" fill="#fff"/></svg>';
+
+test("calcCanvasWidth scales with board size and quality", () => {
+  const base = calcCanvasWidth(8, true, 1, false);
+  const double = calcCanvasWidth(8, true, 2, false);
+
+  assert.ok(base > 0);
+  assert.ok(double > base);
+  assert.equal(calcCanvasWidth(8, true, 1, false), calcCanvasWidth(8, true, 1, false));
+});
+
+test("calcCanvasWidth matches the on-screen 8cm/600 DPI surface", () => {
+  // (8 / 2.54) * 600 = 1890 px board + 5% coordinate border
+  assert.equal(calcCanvasWidth(8, true, 2, false), 1985);
+});
+
+test("intrinsicPxOf converts px/mm/pt dimensions to pixels", () => {
+  assert.equal(intrinsicPxOf('<svg width="512" height="512"/>'), 512);
+  assert.equal(intrinsicPxOf('<svg width="50mm" height="50mm" viewBox="0 0 50 50"/>'), 189);
+  assert.equal(intrinsicPxOf('<svg width="700pt" height="700pt" viewBox="0 0 933 933"/>'), 933);
+  assert.equal(intrinsicPxOf('<svg viewBox="0 0 45 45"/>'), 0);
+});
+
+test("resizePieceSvg overrides root width/height attributes", () => {
+  const resized = resizePieceSvg(PIECE_SVG, 1200);
+  const match = /<svg([^>]*?)>/.exec(resized);
+
+  assert.ok(match, "root svg tag preserved");
+  assert.match(match[1], /\swidth="1200"/);
+  assert.match(match[1], /\sheight="1200"/);
+});
+
+test("resizePieceSvg adds width/height when absent", () => {
+  const resized = resizePieceSvg(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 45 45"></svg>',
+    800,
+  );
+  const match = /<svg([^>]*?)>/.exec(resized);
+
+  assert.ok(match, "root svg tag preserved");
+  assert.match(match[1], /\swidth="800"/);
+  assert.match(match[1], /\sheight="800"/);
+});
+
+test("buildBoardSvg never shrinks piece intrinsic below source size", () => {
+  const svg = buildBoardSvg({
+    fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    pieceStyle: "cburnett",
+    showCoords: true,
+    boardSize: 8,
+    exportQuality: 1,
+    lightSquare: "#f0d9b5",
+    darkSquare: "#b58863",
+  });
+
+  const match = /<image href="data:image\/svg\+xml;base64,([^"]+)"/.exec(svg);
+  assert.ok(match, "embedded piece data URL found");
+
+  const pieceSvg = Buffer.from(match[1], "base64").toString("utf8");
+  // cburnett source is 512px; a low-res export must not shrink it
+  assert.match(pieceSvg, /\swidth="512"/);
+  assert.match(pieceSvg, /\sheight="512"/);
+});
+
+test("buildBoardSvg embeds pieces without breaking the document", () => {
+  const svg = buildBoardSvg({
+    fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    pieceStyle: "cburnett",
+    showCoords: true,
+    boardSize: 8,
+    exportQuality: 4,
+    lightSquare: "#f0d9b5",
+    darkSquare: "#b58863",
+  });
+
+  assert.match(svg, /^<svg/);
+  assert.match(svg, /<image href="data:image\/svg\+xml;base64,/);
+  assert.match(svg, /<\/svg>$/);
+});


### PR DESCRIPTION
## What & why

High-res export now renders the embedded piece SVGs at the target output pixel size instead of their source intrinsic size. Sets with a low intrinsic resolution (e.g. `california` at 100px) were upscaled by browsers that rasterize nested SVG at its intrinsic size, which produces a soft image in high-DPI exports; the pieces are now resized to the computed output size (clamped 64–2048px) while never shrinking below the set's own artwork, so rasterization stays sharp in any browser and larger sets keep their supersampling advantage.

## Checklist

- [x] `pnpm validate` passes locally
- [x] No `any` / `@ts-ignore` / non-null `!` introduced
- [ ] Screenshots or a screen recording added — only if this changes the UI